### PR TITLE
 WSDL updates regarding ONVIF 26.06 release

### DIFF
--- a/onvif/services/media2.py
+++ b/onvif/services/media2.py
@@ -311,6 +311,14 @@ class Media2(ONVIFService):
             RepeatCycles=RepeatCycles,
         )
 
+    def AddTTSAudioClip(self, Configuration, TTSConfiguration, Token=None):
+        return self.operator.call(
+            "AddTTSAudioClip",
+            Token=Token,
+            Configuration=Configuration,
+            TTSConfiguration=TTSConfiguration,
+        )
+
     def GetPlayingAudioClips(self):
         return self.operator.call("GetPlayingAudioClips")
 

--- a/onvif/services/recording.py
+++ b/onvif/services/recording.py
@@ -139,3 +139,33 @@ class Recording(ONVIFService):
             Expiration=Expiration,
             RecordingConfiguration=RecordingConfiguration,
         )
+
+    def ListRecordedSegments(self, Time, RecordingToken, MaxResults=None):
+        return self.operator.call(
+            "ListRecordedSegments",
+            Time=Time,
+            RecordingToken=RecordingToken,
+            MaxResults=MaxResults,
+        )
+
+    def ExportRecordedSegments(
+        self,
+        Time,
+        RecordingToken,
+        Alias=None,
+        StorageToken=None,
+        Track=None,
+    ):
+        return self.operator.call(
+            "ExportRecordedSegments",
+            Time=Time,
+            RecordingToken=RecordingToken,
+            Alias=Alias,
+            StorageToken=StorageToken,
+            Track=Track,
+        )
+
+    def StopExportRecordedSegments(self, OperationToken):
+        return self.operator.call(
+            "StopExportRecordedSegments", OperationToken=OperationToken
+        )

--- a/onvif/services/search.py
+++ b/onvif/services/search.py
@@ -152,3 +152,67 @@ class Search(ONVIFService):
             MaxResults=MaxResults,
             WaitTime=WaitTime,
         )
+
+    def SearchImageByNL(
+        self,
+        StartPoint,
+        Text,
+        KeepAliveTime,
+        EndPoint=None,
+        RecordingToken=None,
+        Similarity=None,
+        MaxMatches=None,
+    ):
+        return self.operator.call(
+            "SearchImageByNL",
+            StartPoint=StartPoint,
+            EndPoint=EndPoint,
+            RecordingToken=RecordingToken,
+            Text=Text,
+            Similarity=Similarity,
+            MaxMatches=MaxMatches,
+            KeepAliveTime=KeepAliveTime,
+        )
+
+    def GetNLSearchResults(
+        self, SearchToken, MinResults=None, MaxResults=None, WaitTime=None
+    ):
+        return self.operator.call(
+            "GetNLSearchResults",
+            SearchToken=SearchToken,
+            MinResults=MinResults,
+            MaxResults=MaxResults,
+            WaitTime=WaitTime,
+        )
+
+    def SearchImageByImage(
+        self,
+        StartPoint,
+        KeepAliveTime,
+        EndPoint=None,
+        RecordingToken=None,
+        TargetImageURI=None,
+        TargetImageData=None,
+        MaxMatches=None,
+    ):
+        return self.operator.call(
+            "SearchImageByImage",
+            StartPoint=StartPoint,
+            EndPoint=EndPoint,
+            RecordingToken=RecordingToken,
+            TargetImageURI=TargetImageURI,
+            TargetImageData=TargetImageData,
+            MaxMatches=MaxMatches,
+            KeepAliveTime=KeepAliveTime,
+        )
+
+    def GetImageSearchResults(
+        self, SearchToken, MinResults=None, MaxResults=None, WaitTime=None
+    ):
+        return self.operator.call(
+            "GetImageSearchResults",
+            SearchToken=SearchToken,
+            MinResults=MinResults,
+            MaxResults=MaxResults,
+            WaitTime=WaitTime,
+        )

--- a/onvif/utils/service.py
+++ b/onvif/utils/service.py
@@ -131,16 +131,20 @@ class ONVIFService:
 
         Example:
             device = client.devicemgmt()
-            
+
             info = device.GetDeviceInformation()
             info_dict = device.to_dict(info)
             print(info_dict)
-            
+
             profiles = media.GetProfiles()
             profiles_dict = device.to_dict(profiles)
         """
         try:
-            return {} if zeep_object is None else zeep.helpers.serialize_object(zeep_object)
+            return (
+                {}
+                if zeep_object is None
+                else zeep.helpers.serialize_object(zeep_object)
+            )
         except Exception as e:
             logger.error(f"Failed to convert zeep object to dict: {e}")
             return {}

--- a/onvif/wsdl/ver10/accessrules/wsdl/accessrules.wsdl
+++ b/onvif/wsdl/ver10/accessrules/wsdl/accessrules.wsdl
@@ -136,7 +136,7 @@ CERTAIN WRITTEN POLICIES OF THE CORPORATION.
 							<xs:documentation>
 								Optional entity type; if missing, an access point type as defined by the ONVIF Access
 								Control Service Specification should be assumed. This can also be represented by the
-								QName value	“tac:AccessPoint” where tac is the namespace of ONVIF Access Control
+								QName value	"tac:AccessPoint" where tac is the namespace of ONVIF Access Control
 								Service Specification. This field is provided for future extensions; it will allow an
 								access policy being	extended to cover entity types other than access points as well.
 							</xs:documentation>

--- a/onvif/wsdl/ver10/actionengine.wsdl
+++ b/onvif/wsdl/ver10/actionengine.wsdl
@@ -809,7 +809,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:element>
 					<xs:element name="FtpAuthentication" type="tae:FtpAuthenticationConfiguration">
 						<xs:annotation>
-							<xs:documentation>User credentials confguration for target FTP Server</xs:documentation>
+							<xs:documentation>User credentials configuration for target FTP Server</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Extension" type="tae:FtpDestinationConfigurationExtension" minOccurs="0"/>

--- a/onvif/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
+++ b/onvif/wsdl/ver10/advancedsecurity/wsdl/advancedsecurity.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../../../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-	Copyright (c) 2013 - 2025 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+	Copyright (c) 2013 - 2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 	
 	Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 	
@@ -10,7 +10,7 @@
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tas="http://www.onvif.org/ver10/advancedsecurity/wsdl" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://www.onvif.org/ver10/advancedsecurity/wsdl">
 	<wsdl:types>
-		<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tt="http://www.onvif.org/ver10/schema" elementFormDefault="qualified" targetNamespace="http://www.onvif.org/ver10/advancedsecurity/wsdl" version="25.12">
+		<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tt="http://www.onvif.org/ver10/schema" elementFormDefault="qualified" targetNamespace="http://www.onvif.org/ver10/advancedsecurity/wsdl" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../../schema/onvif.xsd"/>
 			<!--===================================================-->
 			<!-- Data types used by the security configuration features -->
@@ -725,7 +725,7 @@
 				</xs:sequence>
 				<xs:attribute name="MaximumNumberOfKeys" type="xs:positiveInteger">
 					<xs:annotation>
-						<xs:documentation>Indicates the maximum number of keys that the device can store simultaneously.</xs:documentation>
+						<xs:documentation>Indicates the maximum number of private keys that the device can store simultaneously.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="MaximumNumberOfCertificates" type="xs:positiveInteger">
@@ -805,7 +805,7 @@
 				</xs:attribute>
 				<xs:attribute name="PKCS8" type="xs:boolean">
 					<xs:annotation>
-						<xs:documentation>Indicates support for uploading a key pair in a PKCS#8 data structure.</xs:documentation>
+						<xs:documentation>Deprecated - Indicates support for uploading a key pair in a PKCS#8 data structure.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="PKCS12CertificateWithRSAPrivateKeyUpload" type="xs:boolean">
@@ -825,7 +825,7 @@
 				</xs:attribute>
 				<xs:attribute name="PasswordBasedMACAlgorithms" type="tas:PasswordBasedMACAlgorithms">
 					<xs:annotation>
-						<xs:documentation>Indicates which password-based MAC algorithms are supported by the device.</xs:documentation>
+						<xs:documentation>Deprecated - Indicates which password-based MAC algorithms are supported by the device.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<!-- ========================================= -->
@@ -2473,7 +2473,8 @@
 					<xs:sequence>
 						<xs:element name="CertificationPathID" type="tas:CertificationPathID" minOccurs="0" maxOccurs="2">
 							<xs:annotation>
-								<xs:documentation>The IDs of all certification paths that are assigned for media signing.</xs:documentation>
+								<xs:documentation>The IDs of all certification paths that are assigned for media signing. Response list shall be ordered with factory-provisioned ID first, followed by user-provisioned ID.
+								As response structure includes just CertificationPathID, the client may retrieve the assigned media signing certificates by invoking GetCertificationPath with the CertificationPathID, followed by GetCertificates</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
@@ -3466,49 +3467,78 @@
 		<wsdl:documentation>802.1X configuration.</wsdl:documentation>
 		<wsdl:operation name="AddDot1XConfiguration">
 			<wsdl:documentation>
-				(to be written)
+				This operation adds an IEEE 802.1X configuration to the device.
+        		Configurations are uniquely identified using IEEE 802.1X configuration IDs. The device shall ignore Dot1XID in the request, if present, and shall generate a unique configuration ID for the added configuration.
+        		If the command was successful, the device shall return the ID of the configuration.
+        		If the device does not have capacity for the configuration, the device shall produce a MaximumNumberOfDot1XConfigurationsReached fault and shall not add the configuration.
+        		If Identity is used as an anonymous identity for the corresponding authentication method, the device shall ignore an eventually supplied passphrase ID in the same Dot1XStage. Otherwise, if the device cannot process a passphrase ID included in the configuration to be added, the device shall produce a PassphraseID fault and shall not add the configuration.
+        		If the device cannot process a certification path ID included in the configuration to be added, the device shall produce a CertificationPathID fault and shall not add the configuration.
+        		If no certification path validation policy is stored under the requested certification path validation policy ID, the device shall produce a CertPathValidationPolicyID fault.
+        		If no certification path validation policy configured, authorization server certificate validation behavior is undefined and the device may either apply a vendor specific default validation policy or skip validation at all.
+        		If the device cannot process an authentication method included in the configuration to be added (e.g., unrecognized method or missing configuration parameter), the device shall produce a Dot1XMethod fault and shall not add the configuration.
+        		A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.
 			</wsdl:documentation>
 			<wsdl:input message="tas:AddDot1XConfigurationRequest"/>
 			<wsdl:output message="tas:AddDot1XConfigurationResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="GetAllDot1XConfigurations">
 			<wsdl:documentation>
-				(to be written)
+				This operation returns details of all IEEE 802.1X configurations that are on the device. This operation may be used, e.g., if a client lost track of which IEEE 802.1X configurations are present on the device.
+        		If no IEEE 802.1X configurations exist on the device, an empty list is returned.
+        		A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.
 			</wsdl:documentation>
 			<wsdl:input message="tas:GetAllDot1XConfigurationsRequest"/>
 			<wsdl:output message="tas:GetAllDot1XConfigurationsResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="GetDot1XConfiguration">
 			<wsdl:documentation>
-				(to be written)
+				This operation returns details of a specific IEEE 802.1X configuration on the device.
+        		If the device cannot process the provided IEEE 802.1X configuration ID, the device shall produce a Dot1XConfigurationID fault.
+        		A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.
 			</wsdl:documentation>
 			<wsdl:input message="tas:GetDot1XConfigurationRequest"/>
 			<wsdl:output message="tas:GetDot1XConfigurationResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="DeleteDot1XConfiguration">
 			<wsdl:documentation>
-				(to be written)
+				This operation deletes an IEEE 802.1X configuration from the device.
+        		If the device cannot process the provided IEEE 802.1X configuration ID, the device shall produce a Dot1XConfigurationID fault.
+        		If a reference exists for the specified IEEE 802.1X configuration, the device shall  produce a ReferenceExists fault and shall not delete the configuration.
+        		After an IEEE 802.1X configuration has been successfully deleted, the device may assign its former ID to a new configuration.
+        		A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.
 			</wsdl:documentation>
 			<wsdl:input message="tas:DeleteDot1XConfigurationRequest"/>
 			<wsdl:output message="tas:DeleteDot1XConfigurationResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="SetNetworkInterfaceDot1XConfiguration">
 			<wsdl:documentation>
-				(to be written)
+				This operation binds an IEEE 802.1X configuration to a network interface on the device. This operation shall either create a new binding or replace an existing binding. On failure when an existing binding already exists, the existing binding shall remain.
+        		The Device Management SetNetworkInterface operation provides a method of binding an IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, and that operation may still be used. But there is no ability for SetNetworkInterface to bind an IEEE 802.1X configuration to a hardwired interface. This operation is provided to bind an IEEE 802.1X configuration to either type of interface.
+        		If SetNetworkInterfaceDot1XConfiguration is used to bind an IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, then the DeviceManagement GetNetworkInterfaces operation shall return the IEEE 802.1X configuration ID along with the rest of that interface's configuration information.
+        		If the device cannot process the provided network interface token, the device shall produce an InvalidNetworkInterface fault.
+        		If the device cannot process the provided IEEE 802.1X configuration ID, the device shall produce a Dot1XConfigurationID fault.
+        		A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.
 			</wsdl:documentation>
 			<wsdl:input message="tas:SetNetworkInterfaceDot1XConfigurationRequest"/>
 			<wsdl:output message="tas:SetNetworkInterfaceDot1XConfigurationResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="GetNetworkInterfaceDot1XConfiguration">
 			<wsdl:documentation>
-				(to be written)
+				This operation returns the IEEE 802.1X ID and configuration associated with a network interface on the device. If there is no IEEE 802.1X configuration associated with the specified network interface, then the response shall be empty.
+        		If the Device Management SetNetworkInterface operation was used to bind an IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, then this operation shall return the IEEE 802.1X configuration information as if the SetNetworkInterfaceDot1XConfiguration operation had been used.
+        		If the device cannot process the provided network interface token, the device shall produce an InvalidNetworkInterface fault.
+    			A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.
 			</wsdl:documentation>
 			<wsdl:input message="tas:GetNetworkInterfaceDot1XConfigurationRequest"/>
 			<wsdl:output message="tas:GetNetworkInterfaceDot1XConfigurationResponse"/>
 		</wsdl:operation>
 		<wsdl:operation name="DeleteNetworkInterfaceDot1XConfiguration">
 			<wsdl:documentation>
-				(to be written)
+				This operation unbinds the IEEE 802.1X configuration associated with a network interface on the device. If there is no IEEE 802.1X configuration associated with the specified network interface, then the operation does nothing.
+        		The Device Management SetNetworkInterface operation provides a method of unbinding an IEEE 802.1X configuration from an IEEE 802.11 (wireless) interface by omitting the configuration ID, and that operation may still be used. But there is no ability for SetNetworkInterface to unbind an IEEE 802.1X configuration from a hardwired interface. This operation is provided to unbind an IEEE 802.1X configuration from either type of interface.
+        		If the Device Management SetNetworkInterface operation was used to bind an IEEE 802.1X configuration to an IEEE 802.11 (wireless) interface, then this operation shall unbind the IEEE 802.1X configuration information as if the SetNetworkInterfaceDot1XConfiguration operation had been used.
+        		If the device cannot process the provided network interface token, the device shall produce an InvalidNetworkInterface fault.
+        		A device signalling support for IEEE 802.1X configuration with the MaximumNumberOfDot1XConfigurations capability shall support this command.
 			</wsdl:documentation>
 			<wsdl:input message="tas:DeleteNetworkInterfaceDot1XConfigurationRequest"/>
 			<wsdl:output message="tas:DeleteNetworkInterfaceDot1XConfigurationResponse"/>

--- a/onvif/wsdl/ver10/analyticsdevice.wsdl
+++ b/onvif/wsdl/ver10/analyticsdevice.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-Copyright (c) 2008-2010 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+Copyright (c) 2008-2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 
 Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 
@@ -10,7 +10,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tad="http://www.onvif.org/ver10/analyticsdevice/wsdl" targetNamespace="http://www.onvif.org/ver10/analyticsdevice/wsdl">
 	<wsdl:types>
-		<xs:schema targetNamespace="http://www.onvif.org/ver10/analyticsdevice/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="25.12">
+		<xs:schema targetNamespace="http://www.onvif.org/ver10/analyticsdevice/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../ver10/schema/onvif.xsd"/>
 			<!--===============================-->
 			<xs:element name="GetServiceCapabilities">

--- a/onvif/wsdl/ver10/credential/wsdl/credential.wsdl
+++ b/onvif/wsdl/ver10/credential/wsdl/credential.wsdl
@@ -126,7 +126,7 @@ CERTAIN WRITTEN POLICIES OF THE CORPORATION.
 						<xs:documentation>
 							The default time period that the credential will temporary be suspended (e.g. by using
 							the wrong PIN a predetermined number of times).
-							The time period is defined as an [ISO 8601] duration string (e.g. “PT5M”).
+							The time period is defined as an [ISO 8601] duration string (e.g. "PT5M").
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>

--- a/onvif/wsdl/ver10/device/wsdl/devicemgmt.wsdl
+++ b/onvif/wsdl/ver10/device/wsdl/devicemgmt.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../../../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-Copyright (c) 2008-2025 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+Copyright (c) 2008-2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 
 Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 
@@ -10,7 +10,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" targetNamespace="http://www.onvif.org/ver10/device/wsdl">
 	<wsdl:types>
-		<xs:schema targetNamespace="http://www.onvif.org/ver10/device/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" elementFormDefault="qualified" version="25.12">
+		<xs:schema targetNamespace="http://www.onvif.org/ver10/device/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" elementFormDefault="qualified" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../../../ver10/schema/onvif.xsd"/>
 			<!--===============================-->
 			<xs:element name="GetServices">
@@ -304,11 +304,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:attribute name="SystemLogging" type="xs:boolean">
 					<xs:annotation>
 						<xs:documentation>Indicates support for retrieval of system logging through MTOM.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-				<xs:attribute name="FirmwareUpgrade" type="xs:boolean">
-					<xs:annotation>
-						<xs:documentation>Indicates support for firmware upgrade through MTOM.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:attribute name="CloudFirmwareUpgrade" type="xs:boolean">
@@ -3661,9 +3656,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<li>Server reprograms itself using the uploaded image, then reboots.</li>
 				</ol>
 				If the firmware upgrade fails because the upgrade file was invalid, the HTTP POST response
-				shall be “415 Unsupported Media Type”. If the firmware upgrade fails due to an error at the
-				device, the HTTP POST response shall be “500 Internal Server Error”.<br/>
-				The value of the Content-Type header in the HTTP POST request shall be “application/octetstream”.</wsdl:documentation>
+				shall be "415 Unsupported Media Type". If the firmware upgrade fails due to an error at the
+				device, the HTTP POST response shall be "500 Internal Server Error".<br/>
+				The value of the Content-Type header in the HTTP POST request shall be "application/octetstream".</wsdl:documentation>
 			<wsdl:input message="tds:StartFirmwareUpgradeRequest"/>
 			<wsdl:output message="tds:StartFirmwareUpgradeResponse"/>
 		</wsdl:operation>
@@ -3699,9 +3694,9 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<li>Server applies the uploaded configuration, then reboots if necessary.</li>
 				</ol>
 				If the system restore fails because the uploaded file was invalid, the HTTP POST response
-				shall be “415 Unsupported Media Type”. If the system restore fails due to an error at the
-				device, the HTTP POST response shall be “500 Internal Server Error”.<br/>
-				The value of the Content-Type header in the HTTP POST request shall be “application/octetstream”.</wsdl:documentation>
+				shall be "415 Unsupported Media Type". If the system restore fails due to an error at the
+				device, the HTTP POST response shall be "500 Internal Server Error".<br/>
+				The value of the Content-Type header in the HTTP POST request shall be "application/octetstream".</wsdl:documentation>
 			<wsdl:input message="tds:StartSystemRestoreRequest"/>
 			<wsdl:output message="tds:StartSystemRestoreResponse"/>
 		</wsdl:operation>

--- a/onvif/wsdl/ver10/events/wsdl/event-vs.wsdl
+++ b/onvif/wsdl/ver10/events/wsdl/event-vs.wsdl
@@ -551,7 +551,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				deletion in a uniform way. When a client wants to synchronize its properties with the
 				properties of the device, it can request a synchronization point which repeats the current
 				status of all properties to which a client has subscribed. The PropertyOperation of all
-				produced notifications is set to “Initialized”. The Synchronization Point is
+				produced notifications is set to "Initialized". The Synchronization Point is
 				requested directly from the SubscriptionManager which was returned in either the
 				SubscriptionResponse or in the CreatePullPointSubscriptionResponse. The property update is
 				transmitted via the notification transportation of the notification interface. This method is mandatory.

--- a/onvif/wsdl/ver10/events/wsdl/event.wsdl
+++ b/onvif/wsdl/ver10/events/wsdl/event.wsdl
@@ -387,7 +387,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:annotation>
 							<xs:documentation>Concrete Topic Expression to select specific metadata topics to publish.</xs:documentation>
 						</xs:annotation>
-					</xs:element>					
+					</xs:element>				
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
 				<xs:anyAttribute processContents="lax"/>
@@ -551,7 +551,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				deletion in a uniform way. When a client wants to synchronize its properties with the
 				properties of the device, it can request a synchronization point which repeats the current
 				status of all properties to which a client has subscribed. The PropertyOperation of all
-				produced notifications is set to “Initialized”. The Synchronization Point is
+				produced notifications is set to "Initialized". The Synchronization Point is
 				requested directly from the SubscriptionManager which was returned in either the
 				SubscriptionResponse or in the CreatePullPointSubscriptionResponse. The property update is
 				transmitted via the notification transportation of the notification interface. This method is mandatory.

--- a/onvif/wsdl/ver10/media/wsdl/media.wsdl
+++ b/onvif/wsdl/ver10/media/wsdl/media.wsdl
@@ -210,7 +210,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:sequence>
 						<xs:element name="ProfileToken" type="tt:ReferenceToken">
 							<xs:annotation>
-								<xs:documentation>this command requests a specific profile</xs:documentation>
+								<xs:documentation>This command requests a specific profile.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
@@ -221,7 +221,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:sequence>
 						<xs:element name="Profile" type="tt:Profile">
 							<xs:annotation>
-								<xs:documentation>returns the requested media profile</xs:documentation>
+								<xs:documentation>Returns the requested media profile.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
@@ -1587,7 +1587,7 @@ AudioOutputConfiguration shall be removed.</xs:documentation>
 					<xs:sequence>
 						<xs:element name="StreamSetup" type="tt:StreamSetup">
 							<xs:annotation>
-								<xs:documentation>Stream Setup that should be used with the uri</xs:documentation>
+								<xs:documentation>Stream Setup that should be used with the uri.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="ProfileToken" type="tt:ReferenceToken">
@@ -2429,7 +2429,7 @@ AudioOutputConfiguration shall be removed.</xs:documentation>
 		<!--===============================-->
 		<wsdl:operation name="CreateProfile">
 			<wsdl:documentation>This operation creates a new empty media profile. The media profile shall be created in the
-device and shall be persistent (remain after reboot). A created profile shall be deletable and a device shall set the “fixed” attribute to false in the
+device and shall be persistent (remain after reboot). A created profile shall be deletable and a device shall set the "fixed" attribute to false in the
 returned Profile.</wsdl:documentation>
 			<wsdl:input message="trt:CreateProfileRequest"/>
 			<wsdl:output message="trt:CreateProfileResponse"/>

--- a/onvif/wsdl/ver10/receiver.wsdl
+++ b/onvif/wsdl/ver10/receiver.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-Copyright (c) 2008-2010 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+Copyright (c) 2008-2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 
 Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 
@@ -10,7 +10,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:trv="http://www.onvif.org/ver10/receiver/wsdl" targetNamespace="http://www.onvif.org/ver10/receiver/wsdl">
 	<wsdl:types>
-		<xs:schema targetNamespace="http://www.onvif.org/ver10/receiver/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="2.1.1">
+		<xs:schema targetNamespace="http://www.onvif.org/ver10/receiver/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../ver10/schema/onvif.xsd"/>
 			<!--  Message Request/Responses elements  -->
 			<!--===============================-->

--- a/onvif/wsdl/ver10/recording.wsdl
+++ b/onvif/wsdl/ver10/recording.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-Copyright (c) 2008-2025 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+Copyright (c) 2008-2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 
 Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 
@@ -10,7 +10,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:trc="http://www.onvif.org/ver10/recording/wsdl" targetNamespace="http://www.onvif.org/ver10/recording/wsdl">
 	<wsdl:types>
-		<xs:schema targetNamespace="http://www.onvif.org/ver10/recording/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="25.12">
+		<xs:schema targetNamespace="http://www.onvif.org/ver10/recording/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../ver10/schema/onvif.xsd"/>
 			<!--  Message Request/Responses elements  -->
 			<!--===============================-->
@@ -143,6 +143,27 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:annotation>
 						<xs:documentation>
 							Indicates if the device supports asymmetric encryption.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="ScheduledRecording" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>
+							Indicates if the device supports scheduled recording.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="OnboardStorage" type="xs:boolean" default="true">
+					<xs:annotation>
+						<xs:documentation>
+							Indicates if the device supports recording to onboard storage, default value is true. If false, device shall support recording to an external target.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="SegmentExport" type="xs:boolean">
+					<xs:annotation>
+						<xs:documentation>
+							Indicates support for ExportRecordedSegments.
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -594,7 +615,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-
 			<xs:element name="StopExportRecordedData">
 				<xs:complexType>
 					<xs:sequence>
@@ -623,7 +643,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-
 			<xs:element name="GetExportRecordedDataState">
 				<xs:complexType>
 					<xs:sequence>
@@ -650,6 +669,134 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						</xs:element>
 						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	 <!-- first Vendor then ONVIF -->
 					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+
+			<!--===============================-->
+			<xs:element name="ListRecordedSegments">
+				<xs:annotation>
+					<xs:documentation>Gets segments available within a time range.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Time" type="tt:DateTimeRange">
+							<xs:annotation>
+								<xs:documentation>The start to end time of the query.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="RecordingToken" type="tt:RecordingReference">
+							<xs:annotation>
+								<xs:documentation>The recording configuration token.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="MaxResults" type="xs:int" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>The maximum number of results to return in one response.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ListRecordedSegmentsResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Results" type="trc:SegmentListResult"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:complexType name="SegmentListResult">
+				<xs:sequence>
+					<xs:element name="Segment" minOccurs="0" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:documentation>Information about an exportable segment.</xs:documentation>
+						</xs:annotation>
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="StartTime" type="xs:dateTime">
+									<xs:annotation>
+										<xs:documentation>Same precision as defined in the Recording Control specification for segment objects.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+								<xs:element name="EndTime" type="xs:dateTime">
+									<xs:annotation>
+										<xs:documentation>Same precision as defined in the Recording Control specification for segment objects.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+								<xs:element name="MediaType" type="xs:string">
+									<xs:annotation>
+										<xs:documentation>As defined in RFC 6381 including section 3 Codecs.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+								<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+							</xs:sequence>
+							<xs:anyAttribute processContents="lax"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="HasMoreResults" type="xs:boolean" minOccurs="1">
+						<xs:annotation>
+							<xs:documentation>A value indicating that the search has reached the maximum count and a new request must be sent to continue the search.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+			</xs:complexType>
+			<xs:element name="ExportRecordedSegments">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Time" type="tt:DateTimeRange">
+							<xs:annotation>
+								<xs:documentation>The start to end time of the query.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="RecordingToken" type="tt:RecordingReference">
+							<xs:annotation>
+								<xs:documentation>The recording configuration token.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Alias" type="xs:string" minOccurs="0" maxOccurs="1">
+							<xs:annotation>
+								<xs:documentation>An optional alias that shall be included in the Monitoring/AsynchronousOperationStatus events.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="StorageToken" type="tt:ReferenceToken" minOccurs="0" maxOccurs="1">
+							<xs:annotation>
+								<xs:documentation>If provided, overrides the Target's storage configuration.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Track" type="xs:string" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>An optional track filter for segments to export when in CMAF. For valid definitions see tt:TrackType.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ExportRecordedSegmentsResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="OperationToken" type="tt:ReferenceToken">
+							<xs:annotation>
+								<xs:documentation>Unique operation token for client to query the status of the export.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+
+			<xs:element name="StopExportRecordedSegments">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="OperationToken" type="tt:ReferenceToken">
+							<xs:annotation>
+								<xs:documentation>Unique ExportRecordedSegments operation token</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="StopExportRecordedSegmentsResponse">
+				<xs:complexType>
+					<xs:sequence/>
 				</xs:complexType>
 			</xs:element>
 
@@ -833,12 +980,29 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<wsdl:message name="GetRecordingJobStateResponse">
 		<wsdl:part name="parameters" element="trc:GetRecordingJobStateResponse"/>
 	</wsdl:message>
-
+	<wsdl:message name="ListRecordedSegments">
+		<wsdl:part name="parameters" element="trc:ListRecordedSegments"/>
+	</wsdl:message>
+	<wsdl:message name="ListRecordedSegmentsResponse">
+		<wsdl:part name="parameters" element="trc:ListRecordedSegmentsResponse"/>
+	</wsdl:message>
+	<wsdl:message name="ExportRecordedSegments">
+		<wsdl:part name="parameters" element="trc:ExportRecordedSegments"/>
+	</wsdl:message>
+	<wsdl:message name="ExportRecordedSegmentsResponse">
+		<wsdl:part name="parameters" element="trc:ExportRecordedSegmentsResponse"/>
+	</wsdl:message>
 	<wsdl:message name="ExportRecordedDataRequest">
 		<wsdl:part name="parameters" element="trc:ExportRecordedData"/>
 	</wsdl:message>
 	<wsdl:message name="ExportRecordedDataResponse">
 		<wsdl:part name="parameters" element="trc:ExportRecordedDataResponse"/>
+	</wsdl:message>
+	<wsdl:message name="StopExportRecordedSegments">
+		<wsdl:part name="parameters" element="trc:StopExportRecordedSegments"/>
+	</wsdl:message>
+	<wsdl:message name="StopExportRecordedSegmentsResponse">
+		<wsdl:part name="parameters" element="trc:StopExportRecordedSegmentsResponse"/>
 	</wsdl:message>
 	<wsdl:message name="StopExportRecordedDataRequest">
 		<wsdl:part name="parameters" element="trc:StopExportRecordedData"/>
@@ -879,8 +1043,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<li>
 					META001 Metadata</li>
 				</ul>
-				All TrackConfigurations shall have the MaximumRetentionTime set to 0 (unlimited), and the
-				Description set to the empty string.
+				All tracks created as response to a CreateRecording request shall have the MaximumRetentionTime set to 0 (unlimited), and the
+				Description set to the empty string, by default.
 			</wsdl:documentation>
 			<wsdl:input message="trc:CreateRecordingRequest"/>
 			<wsdl:output message="trc:CreateRecordingResponse"/>
@@ -994,6 +1158,26 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<wsdl:output message="trc:GetRecordingJobStateResponse"/>
 		</wsdl:operation>
 
+		<!--===============================-->
+		<wsdl:operation name="ListRecordedSegments">
+			<wsdl:documentation>Lists available recorded segments related to the specified RecordingToken.</wsdl:documentation>
+			<wsdl:input message="trc:ListRecordedSegments"/>
+			<wsdl:output message="trc:ListRecordedSegmentsResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="ExportRecordedSegments">
+			<wsdl:documentation>
+			Exports the selected recorded segments (from existing recorded data) to the storage attached to the given recording configuration.
+			</wsdl:documentation>
+			<wsdl:input message="trc:ExportRecordedSegments"/>
+			<wsdl:output message="trc:ExportRecordedSegmentsResponse"/>
+		</wsdl:operation>
+		<wsdl:operation name="StopExportRecordedSegments">
+			<wsdl:documentation>
+			Stops the selected ExportRecordedSegments operation.
+			</wsdl:documentation>
+			<wsdl:input message="trc:StopExportRecordedSegments"/>
+			<wsdl:output message="trc:StopExportRecordedSegmentsResponse"/>
+		</wsdl:operation>
 		<wsdl:operation name="ExportRecordedData">
 			<wsdl:documentation>
 			Exports the selected recordings (from existing recorded data) to the given storage target based on the requested file format. 
@@ -1218,6 +1402,33 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<wsdl:operation name="OverrideSegmentDuration">
 			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/OverrideSegmentDuration"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="ListRecordedSegments">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/ListRecordedSegments"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="ExportRecordedSegments">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/ExportRecordedSegments"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="StopExportRecordedSegments">
+			<soap:operation soapAction="http://www.onvif.org/ver10/recording/wsdl/StopExportRecordedSegments"/>
 			<wsdl:input>
 				<soap:body use="literal"/>
 			</wsdl:input>

--- a/onvif/wsdl/ver10/schema/common.xsd
+++ b/onvif/wsdl/ver10/schema/common.xsd
@@ -267,6 +267,15 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- first Vendor then ONVIF -->
 		</xs:sequence>
 	</xs:complexType>
+	<xs:complexType name="AspectRatioTransformation">
+		<xs:sequence>
+			<xs:element name="Translate" type="tt:Vector" minOccurs="0"/>
+			<xs:element name="Scale" type="tt:Vector" minOccurs="0"/>
+            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+        <xs:attribute name="ratio" type="xs:float" use="required"/>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
 	<!--===============================-->
 	<!--  Location/Orientation Types   -->
 	<!--===============================-->

--- a/onvif/wsdl/ver10/schema/metadatastream.xsd
+++ b/onvif/wsdl/ver10/schema/metadatastream.xsd
@@ -293,6 +293,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="Extension" type="tt:FrameExtension" minOccurs="0"/>
 			<xs:element name="SceneImageRef" type="xs:anyURI" minOccurs="0"/>
 			<xs:element name="SceneImage" type="xs:base64Binary" minOccurs="0"/>
+			<xs:element name="AspectRatioTransformation" type="tt:AspectRatioTransformation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 		</xs:sequence>
 		<xs:attribute name="UtcTime" type="xs:dateTime" use="required"/>
@@ -406,7 +407,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:attribute>
 		<xs:attribute name="Cells" type="xs:base64Binary" use="required">
 			<xs:annotation>
-				<xs:documentation>A “1” denotes a cell where motion is detected and a “0” an empty cell. The first cell is in the upper left corner. Then the cell order goes first from left to right and then from up to down.  If the number of cells is not a multiple of 8 the last byte is filled with zeros. The information is run length encoded according to Packbit coding in ISO 12369 (TIFF, Revision 6.0).</xs:documentation>
+				<xs:documentation>A "1" denotes a cell where motion is detected and a "0" an empty cell. The first cell is in the upper left corner. Then the cell order goes first from left to right and then from up to down.  If the number of cells is not a multiple of 8 the last byte is filled with zeros. The information is run length encoded according to Packbit coding in ISO 12369 (TIFF, Revision 6.0).</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
@@ -443,6 +444,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:element name="PTZ" type="tt:PTZStream"/>
 				<xs:element name="Event" type="tt:EventStream"/>
 				<xs:element name="Extension" type="tt:MetadataStreamExtension"/>
+				<xs:element name="SensorData" type="tt:SensorData" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
 			</xs:choice>
 		</xs:sequence>
@@ -459,6 +461,16 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<xs:complexType name="SensorData">
+		<xs:sequence>
+			<xs:element name="Type" type="xs:string" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Value" type="xs:float" minOccurs="1" maxOccurs="1"/>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/> 
+		</xs:sequence>
+		<xs:attribute name="UtcTime" type="xs:dateTime" use="required"/>
+		<xs:attribute name="SensorID" type="xs:string" use="required"/>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<xs:complexType name="AudioAnalyticsStream">

--- a/onvif/wsdl/ver10/schema/onvif.xsd
+++ b/onvif/wsdl/ver10/schema/onvif.xsd
@@ -229,7 +229,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:documentation>
 			A media profile consists of a set of media configurations. Media profiles are used by a client
 			to configure properties of a media stream from an NVT.<br/>
-			An NVT shall provide at least one media profile at boot. An NVT should provide “ready to use”
+			An NVT shall provide at least one media profile at boot. An NVT should provide "ready to use"
 			profiles for the most common media configurations that the device offers.<br/>
 			A profile consists of a set of interconnected configuration entities. Configurations are provided
 			by the NVT and can be either static or created dynamically by the NVT. For example, the
@@ -390,8 +390,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:documentation>Optional element to configure rotation of captured image.
 						What resolutions a device supports shall be unaffected by the Rotate parameters.<br/>
 						If a device is configured with Rotate=AUTO, the device shall take control over the Degree parameter and automatically update it so that a client can query current rotation.<br/>
-						The device shall automatically apply the same rotation to its pan/tilt control direction depending on the following condition: 
-						if Reverse=AUTO in PTControlDirection or if the device doesn’t support Reverse in PTControlDirection
+						The device shall automatically apply the same rotation to its pan/tilt control direction depending on the following condition:
+						if Reverse=AUTO in PTControlDirection or if the device doesn't support Reverse in PTControlDirection
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -405,7 +405,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:annotation><xs:documentation>Optional element describing the geometric lens distortion. Multiple instances for future variable lens support.</xs:documentation></xs:annotation>
 			</xs:element>
 			<xs:element name="SceneOrientation" type="tt:SceneOrientation" minOccurs="0" maxOccurs="1">
-				<xs:annotation><xs:documentation>Optional element describing the scene orientation in the camera’s field of view.</xs:documentation></xs:annotation>
+				<xs:annotation><xs:documentation>Optional element describing the scene orientation in the camera's field of view.</xs:documentation></xs:annotation>
 			</xs:element>
 			<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
@@ -427,8 +427,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</xs:sequence>
 		<xs:attribute name="Mirror" type="xs:boolean">
 			<xs:annotation>
-				<xs:documentation>When enabled, the video will be flipped horizontally. If applied alongside rotation, the mirror effect shall be executed after the rotation. Additionally,<br/> 
-				when Mirror is enabled and Reverse=Auto is set in PTControlDirection or if the device doesn’t support Reverse in PTControlDirection, the device shall automatically adjust the pan direction. 
+				<xs:documentation>When enabled, the video will be flipped horizontally. If applied alongside rotation, the mirror effect shall be executed after the rotation. Additionally,<br/>
+				when Mirror is enabled and Reverse=Auto is set in PTControlDirection or if the device doesn't support Reverse in PTControlDirection, the device shall automatically adjust the pan direction.
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
@@ -487,8 +487,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:annotation><xs:documentation>Offset of the lens center to the imager center in normalized coordinates.</xs:documentation></xs:annotation>
 			</xs:element>
 			<xs:element name="Projection" type="tt:LensProjection" maxOccurs="unbounded">
-				<xs:annotation><xs:documentation>Radial description of the projection characteristics. The resulting curve is defined by the B-Spline interpolation 
-					over the given elements. The element for Radius zero shall not be provided. The projection points shall be ordered with ascending Radius. 
+				<xs:annotation><xs:documentation>Radial description of the projection characteristics. The resulting curve is defined by the B-Spline interpolation
+					over the given elements. The element for Radius zero shall not be provided. The projection points shall be ordered with ascending Radius.
 					Items outside the last projection Radius shall be assumed to be invisible (black).</xs:documentation></xs:annotation>
 			</xs:element>
 			<xs:element name="XFactor" type="xs:float">
@@ -615,13 +615,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						Parameter to assign the way the camera determines the scene orientation.
 					</xs:documentation>
 				</xs:annotation>
-			</xs:element>      
+			</xs:element>
 			<xs:element name="Orientation" type="xs:string" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>
-						Assigned or determined scene orientation based on the Mode. When assigning the Mode to AUTO, this field 
-						is optional and will be ignored by the device. When assigning the Mode to MANUAL, this field is required 
-						and the device will return an InvalidArgs fault if missing. 
+						Assigned or determined scene orientation based on the Mode. When assigning the Mode to AUTO, this field
+						is optional and will be ignored by the device. When assigning the Mode to MANUAL, this field is required
+						and the device will return an InvalidArgs fault if missing.
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -791,7 +791,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="BitrateLimit" type="xs:int">
 				<xs:annotation>
-					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
+					<xs:documentation>The maximum output bitrate in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -1019,6 +1019,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<!--===============================-->
 	<!--   VideoEncoder2Configuration   -->
 	<!--===============================-->
+	<xs:simpleType name="SrtpSecurityAlgorithms">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NONE"/>
+			<xs:enumeration value="AES_CM_128_HMAC_SHA1_80"/>
+			<xs:enumeration value="AEAD_AES_128_GCM"/>
+			<xs:enumeration value="AEAD_AES_256_GCM"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:simpleType name="VideoEncodingMimeNames">
 		<xs:annotation>
 			<xs:documentation>Video Media Subtypes as referenced by IANA (without the leading "video/" Video Media Type).  See also <a href="https://www.iana.org/assignments/media-types/media-types.xhtml#video"> IANA Media Types</a>.</xs:documentation>
@@ -1102,6 +1110,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Indicates if this stream will be signed according to the Media Signing Specification.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="SecureStreamingProtocolAlgorithm" type="xs:string" use="optional">
+					<xs:annotation>
+						<xs:documentation>Defines the cryptographic algorithm to use as defined by tt:SrtpSecurityAlgorithms</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:extension>
 		</xs:complexContent>
@@ -1134,6 +1147,13 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<xs:element name="BitrateLimit" type="xs:int">
 				<xs:annotation>
 					<xs:documentation>the maximum output bitrate in kbps</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AverageBitRate" type="xs:int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The target average output bitrate in kbps. If this parameter is set to 0, AverageBitRate shall be ignored.</xs:documentation>
+					<xs:documentation>If this parameter is configured beyond BitrateLimit, device adapts to BitrateLimit.</xs:documentation>
+					<xs:documentation>When this parameter is set to a non-zero value, ConstantBitRate shall be ignored.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
@@ -1195,11 +1215,26 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:documentation>Signal whether enforcing constant bitrate is supported.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute name="AverageBitRateSupported" type="xs:boolean">
+			<xs:annotation>
+				<xs:documentation>Signal whether enforcing average bitrate is supported.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 		<xs:attribute name="GuaranteedFrameRateSupported" type="xs:boolean">
 			<xs:annotation>
 				<xs:documentation>
 					Indicates the support for the GuaranteedFrameRate attribute on the VideoEncoder2Configuration element.
 				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="SecureStreamingProtocolAlgorithms" type="tt:StringAttrList" use="optional">
+			<xs:annotation>
+				<xs:documentation>If secure RTSP streaming is supported, this shall return the list of supported cryptographic algorithms as defined by tt:SrtpSecurityAlgorithms.</xs:documentation>
+      </xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="SigningSupported" type="xs:boolean">
+			<xs:annotation>
+				<xs:documentation>Indicates the support for signing according to the Media Signing Specification.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
@@ -1249,7 +1284,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:sequence>
 					<xs:element name="Encoding" type="tt:AudioEncoding">
 						<xs:annotation>
-							<xs:documentation>Audio codec used for encoding the audio input (either G.711, G.726 or AAC)</xs:documentation>
+							<xs:documentation>Audio codec used for encoding the audio input (either G.711, G.726 or AAC).</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Bitrate" type="xs:int">
@@ -1302,17 +1337,17 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Encoding" type="tt:AudioEncoding">
 				<xs:annotation>
-					<xs:documentation>The enoding used for audio data (either G.711, G.726 or AAC)</xs:documentation>
+					<xs:documentation>The enoding used for audio data (either G.711, G.726 or AAC).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="BitrateList" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps for the specified Encoding</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps for the specified Encoding.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateList" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported Sample Rates in kHz for the specified Encoding</xs:documentation>
+					<xs:documentation>List of supported Sample Rates in kHz for the specified Encoding.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
@@ -1362,6 +1397,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:element>
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
+				<xs:attribute name="SecureStreamingProtocolAlgorithm" type="xs:string" use="optional">
+					<xs:annotation>
+						<xs:documentation>Defines the cryptographic algorithm to use as defined by tt:SrtpSecurityAlgorithms</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:extension>
 		</xs:complexContent>
@@ -1377,7 +1417,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="BitrateList" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps for the specified Encoding</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps for the specified Encoding.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateList" type="tt:IntItems">
@@ -1387,6 +1427,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 		</xs:sequence>
+		<xs:attribute name="SecureStreamingProtocolAlgorithms" type="tt:StringAttrList" use="optional">
+			<xs:annotation>
+				<xs:documentation>If secure RTSP streaming is supported, this shall return the list of supported cryptographic algorithms as defined by tt:SrtpSecurityAlgorithms.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<!--===============================-->
@@ -1413,12 +1458,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:sequence>
 					<xs:element name="PTZStatus" type="tt:PTZFilter" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation>optional element to configure which PTZ related data is to include in the metadata stream</xs:documentation>
+							<xs:documentation>Optional element to configure which PTZ related data is to include in the metadata stream.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Events" type="tt:EventSubscription" minOccurs="0">
 						<xs:annotation>
-							<xs:documentation>Optional element to configure the streaming of events. A client might be interested in receiving all, 
+							<xs:documentation>Optional element to configure the streaming of events. A client might be interested in receiving all,
 								none or some of the events produced by the device:<ul>
 									<li>To get all events: Include the Events element but do not include a filter.</li>
 									<li>To get no events: Do not include the Events element.</li>
@@ -1449,6 +1494,17 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 							Note that the streaming behavior is undefined if the list includes items that are not part of the associated AnalyticsConfiguration.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="SensorData" type="tt:SensorDataFilter" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Optional element to configure which sensor data is to include in the metadata stream. A client might be interested in receiving all, 
+								none or some of the sensor data produced by the device:<ul>
+									<li>To get all sensor data: Include the SensorData element but do not include any filter criteria.</li>
+									<li>To get no sensor data: Do not include the SensorData element.</li>
+									<li>To get only some sensor data: Include the SensorData element and specify filter criteria (SensorID list, Type list, etc.).</li>
+								</ul>
+							</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element name="Extension" type="tt:MetadataConfigurationExtension" minOccurs="0"/>
 				</xs:sequence>
 				<xs:attribute name="CompressionType" type="xs:string">
@@ -1466,6 +1522,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 						<xs:documentation>Optional parameter to configure if the generated metadata stream should contain shape information as polygon.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="SecureStreamingProtocolAlgorithm" type="xs:string" use="optional">
+					<xs:annotation>
+						<xs:documentation>The cryptographic algorithm used as defined by tt:SrtpSecurityAlgorithms</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:extension>
 		</xs:complexContent>
@@ -1481,26 +1542,52 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:element name="Status" type="xs:boolean">
 				<xs:annotation>
-					<xs:documentation>True if the metadata stream shall contain the PTZ status (IDLE, MOVING or UNKNOWN)</xs:documentation>
+					<xs:documentation>True if the metadata stream shall contain the PTZ status (IDLE, MOVING or UNKNOWN).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Position" type="xs:boolean">
 				<xs:annotation>
-					<xs:documentation>True if the metadata stream shall contain the PTZ position</xs:documentation>
+					<xs:documentation>True if the metadata stream shall contain the PTZ position.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="FieldOfView" type="xs:boolean" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>True if the metadata stream shall contain the field-of-view information</xs:documentation>
+					<xs:documentation>True if the metadata stream shall contain the field-of-view information.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<!--===============================-->
+	<xs:complexType name="SensorDataFilter">
+		<xs:annotation>
+			<xs:documentation>Optional element to configure which sensor data is to include in the metadata stream. A client might be interested in receiving all, none or some of the sensor data produced by the device:
+				<ul>
+					<li>To get all sensor data: Include the SensorData element but do not include any filter criteria.</li>
+					<li>To get no sensor data: Do not include the SensorData element.</li>
+					<li>To get only some sensor data: Include the SensorData element and specify filter criteria (SensorID list, Type list, etc.).</li>
+				</ul>
+			</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="SensorID" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>List of SensorID values to include in the metadata stream. If not specified or empty, all sensor IDs are included (unless other filters exclude them).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Type" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>List of sensor Type values to include in the metadata stream. If not specified or empty, all sensor types are included (unless other filters exclude them).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>	<!-- reserved for ONVIF -->
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
+	</xs:complexType>
+	<!--===============================-->
 	<xs:complexType name="EventSubscription">
 		<xs:annotation>
-			<xs:documentation>Subcription handling in the same way as base notification subscription.</xs:documentation>
+			<xs:documentation>Subscription handling in the same way as base notification subscription.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="Filter" type="wsnt:FilterType" minOccurs="0"/>
@@ -1519,6 +1606,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<xs:complexType name="MetadataConfigurationOptions">
 		<xs:sequence>
 			<xs:element name="PTZStatusFilterOptions" type="tt:PTZStatusFilterOptions"/>
+			<xs:element name="SensorDataFilterOptions" type="tt:SensorDataFilterOptions" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Optional element indicating the sensor data filtering capabilities of the device.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name ="Extension" type="tt:MetadataConfigurationOptionsExtension" minOccurs="0"/>
 		</xs:sequence>
@@ -1530,6 +1622,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:attribute name="MaxContentFilterSize" type="xs:int">
 			<xs:annotation>
 				<xs:documentation>A device signalling support for content filtering shall support expressions with the provided expression size.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="SecureStreamingProtocolAlgorithms" type="tt:StringAttrList" use="optional">
+			<xs:annotation>
+				<xs:documentation>If secure RTSP streaming is supported, this shall return the list of supported cryptographic algorithms as defined by tt:SrtpSecurityAlgorithms.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
@@ -1597,6 +1694,23 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		<xs:sequence>
 			<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
+	</xs:complexType>
+	<!--===============================-->
+	<xs:complexType name="SensorDataFilterOptions">
+		<xs:sequence>
+			<xs:element name="SensorIDFilterSupported" type="xs:boolean">
+				<xs:annotation>
+					<xs:documentation>True if the device supports filtering sensor data by SensorID.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TypeFilterSupported" type="xs:boolean">
+				<xs:annotation>
+					<xs:documentation>True if the device supports filtering sensor data by Type.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<!--===============================-->
 	<!--          VideoOutput            -->
@@ -1697,12 +1811,12 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="SupportedH264Profiles" type="tt:H264Profile" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>List of supported H264 Profiles (either baseline, main, extended or high) </xs:documentation>
+					<xs:documentation>List of supported H264 Profiles (either baseline, main, extended or high).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SupportedInputBitrate" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported H.264 bitrate range in kbps</xs:documentation>
+					<xs:documentation>Supported H.264 bitrate range in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SupportedFrameRate" type="tt:IntRange">
@@ -1724,7 +1838,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="SupportedInputBitrate" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported Jpeg bitrate range in kbps</xs:documentation>
+					<xs:documentation>Supported Jpeg bitrate range in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SupportedFrameRate" type="tt:IntRange">
@@ -1751,7 +1865,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			</xs:element>
 			<xs:element name="SupportedInputBitrate" type="tt:IntRange">
 				<xs:annotation>
-					<xs:documentation>Supported Mpeg4 bitrate range in kbps</xs:documentation>
+					<xs:documentation>Supported Mpeg4 bitrate range in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SupportedFrameRate" type="tt:IntRange">
@@ -1794,7 +1908,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:sequence>
 					<xs:element name="OutputToken" type="tt:ReferenceToken">
 						<xs:annotation>
-							<xs:documentation>Token of the phsycial Audio output.</xs:documentation>
+							<xs:documentation>Token of the physical Audio output.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="SendPrimacy" type="xs:anyURI" minOccurs="0">
@@ -1989,7 +2103,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Bitrate" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateRange" type="tt:IntItems">
@@ -2006,7 +2120,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Bitrate" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateRange" type="tt:IntItems">
@@ -2023,7 +2137,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Bitrate" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateRange" type="tt:IntItems">
@@ -2100,8 +2214,8 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 							<xs:documentation>
 							Defines the RTP payload type used for the audio stream.
 							To ensure compatibility, it is recommended to use dynamic payload types (96 and above), as specified in RFC 3551.
-							Standard payload types (0-95) should only be used for predefined audio formats matching the audio encoding as defined in 
-							<a href="https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1">IANA RTP Payload Types</a>, 
+							Standard payload types (0-95) should only be used for predefined audio formats matching the audio encoding as defined in
+							<a href="https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1">IANA RTP Payload Types</a>,
 							as using them for non-standard media may lead to unexpected errors or interoperability issues.
 							</xs:documentation>
 						</xs:annotation>
@@ -2109,7 +2223,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 					<xs:element name="Priority" type="xs:int">
 						<xs:annotation>
 							<xs:documentation>
-								Indicates the priority level when multiple configurations are active. 
+								Indicates the priority level when multiple configurations are active.
 								A higher value signifies a higher priority. If several configurations have the same priority value the order between those configurations is undefined.
 							</xs:documentation>
 						</xs:annotation>
@@ -2126,6 +2240,8 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 						<xs:annotation>
 							<xs:documentation>
 								 Optional configuration parameters for SRTP pre-shared key usage, applicable when SRTP is supported. When this configuration is present, RTP packets shall be encrypted.
+								 When this configuration is absent, RTP packets shall not be encrypted. 
+								On GetMulticastAudioDecoderConfiguration, this element shall be present only if encryption is enabled; it shall be absent if encryption is disabled.
 							</xs:documentation>
 						</xs:annotation>
 					</xs:element>
@@ -2141,19 +2257,13 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="SRTPPSK" type="xs:string">
 			<xs:annotation>
 				<xs:documentation>
-				An optional SRTP Pre-Shared Key (PSK) represented as a hexadecimal string.
+				SRTP Pre-Shared Key (PSK) represented as a hexadecimal string.
 				This includes both the SRTP master key, followed by the master salt.
-				The sizes of the key and salt depend on the specified SRTPCryptoPolicy.
-				When this element is specified, RTP packets shall be encrypted.
-				The SRTPPSK shall never be returned on a get method.
-				</xs:documentation>
-			</xs:annotation>
-			</xs:element>
-			<xs:element name="SecureStreamingProtocolAlgorithm" type="xs:string">
-			<xs:annotation>
-				<xs:documentation>
-				Specifies the cryptographic algorithm when using SRTP,
-				selecting from predefined values provided in the GetMulticastAudioDecoderConfigurationOptions response.
+				The sizes of the key and salt depend on the specified SecureStreamingProtocolAlgorithm.
+				The SRTPPSK shall be returned as an empty string on a get method.
+				In SetMulticastAudioDecoderConfiguration requests, if SRTPPreSharedParameters is present but 
+				SRTPPSK is empty, the device shall retain the previously configured pre-shared key.
+				To update the PSK, a valid non-empty hexadecimal value must be provided.
 				</xs:documentation>
 			</xs:annotation>
 			</xs:element>
@@ -2167,6 +2277,14 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/> <!-- first Vendor then ONVIF -->
 		</xs:sequence>
+		<xs:attribute name="SecureStreamingProtocolAlgorithm" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>
+				Specifies the cryptographic algorithm when using SRTP,
+				selecting from predefined values provided in the GetMulticastAudioDecoderConfigurationOptions response.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<!--===============================-->
@@ -2179,7 +2297,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="Port" type="xs:int">
 				<xs:annotation>
-					<xs:documentation>The RTP multicast destination port. A device may support RTCP. In this case the port value shall be even to allow the corresponding RTCP stream to be mapped to the next higher (odd) destination port number as defined in the RTSP specification.</xs:documentation>
+					<xs:documentation>The RTP multicast port used for receiving. The RTP port number shall be even. If RTCP is supported, the corresponding RTCP stream shall be mapped to the next higher (odd) port number as defined in RFC 3550.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="TTL" type="xs:int">
@@ -2216,14 +2334,6 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SecureStreamingProtocolAlgorithms" type="tt:StringList" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>
-							An optional parameter specifies the list of supported cryptographic algorithms when SRTP support is signaled as 'true' in the GetServiceCapabilitiesResponse.
-							Refer to tt:SrtpSecurityAlgorithms for the acceptable values.
-							</xs:documentation>
-						</xs:annotation>
-			</xs:element>
 			<xs:element name="AudioOutputTokens" type="tt:StringList" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>
@@ -2233,6 +2343,14 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 		</xs:sequence>
+		<xs:attribute name="SecureStreamingProtocolAlgorithms" type="tt:StringList" use="optional">
+			<xs:annotation>
+				<xs:documentation>
+				An optional parameter specifies the list of supported cryptographic algorithms when SRTP support is signaled as 'true' in the GetServiceCapabilitiesResponse.
+				Refer to tt:SrtpSecurityAlgorithms for the acceptable values.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
 	<!--===============================-->
@@ -2245,7 +2363,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="BitrateList" type="tt:IntItems">
 				<xs:annotation>
-					<xs:documentation>List of supported bitrates in kbps for the specified Encoding</xs:documentation>
+					<xs:documentation>List of supported bitrates in kbps for the specified Encoding.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="SampleRateList" type="tt:IntItems">
@@ -2256,7 +2374,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="RTPPayloadType" type="xs:int" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>
-						Optional element for specifying the RTP payload type, 
+						Optional element for specifying the RTP payload type,
 						particularly when it is fixed for a specific audio encoding as defined in <a href="https://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml#rtp-parameters-1">IANA RTP Payload Types</a>.
 					</xs:documentation>
 				</xs:annotation>
@@ -2272,7 +2390,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Address" type="tt:IPAddress">
 				<xs:annotation>
-					<xs:documentation>The multicast address (if this address is set to 0 no multicast streaming is enaled)</xs:documentation>
+					<xs:documentation>The multicast address (if this address is set to 0 no multicast streaming is enabled)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Port" type="xs:int">
@@ -2287,7 +2405,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="AutoStart" type="xs:boolean">
 				<xs:annotation>
-					<xs:documentation>Read only property signalling that streaming is persistant. Use the methods StartMulticastStreaming and StopMulticastStreaming to switch its state.</xs:documentation>
+					<xs:documentation>Read only property signalling that streaming is persistent. Use the methods StartMulticastStreaming and StopMulticastStreaming to switch its state.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
@@ -2299,7 +2417,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Stream" type="tt:StreamType">
 				<xs:annotation>
-					<xs:documentation>Defines if a multicast or unicast stream is requested</xs:documentation>
+					<xs:documentation>Defines if a multicast or unicast stream is requested.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Transport" type="tt:Transport"/>
@@ -2319,13 +2437,18 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Protocol" type="tt:TransportProtocol">
 				<xs:annotation>
-					<xs:documentation>Defines the network protocol for streaming, either UDP=RTP/UDP, RTSP=RTP/RTSP/TCP or HTTP=RTP/RTSP/HTTP/TCP </xs:documentation>
+					<xs:documentation>Defines the network protocol for streaming, either UDP=RTP/UDP, RTSP=RTP/RTSP/TCP or HTTP=RTP/RTSP/HTTP/TCP.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Tunnel" type="tt:Transport" minOccurs="0">
+			<xs:element name="Tunnel" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Optional element to describe further tunnel options. This element is normally not needed </xs:documentation>
+					<xs:documentation>Deprecated: optional element to describe further tunnel options.</xs:documentation>
 				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- placeholder for tt:Transport -->
+					</xs:sequence>
+				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
@@ -2347,7 +2470,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="Uri" type="xs:anyURI">
 				<xs:annotation>
-					<xs:documentation>Stable Uri to be used for requesting the media stream</xs:documentation>
+					<xs:documentation>Stable Uri to be used for requesting the media stream.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="InvalidAfterConnect" type="xs:boolean">
@@ -2362,7 +2485,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			</xs:element>
 			<xs:element name="Timeout" type="xs:duration">
 				<xs:annotation>
-					<xs:documentation>Duration how long the Uri is valid. This parameter shall be set to PT0S to indicate that this stream URI is indefinitely valid even if the profile changes</xs:documentation>
+					<xs:documentation>Duration how long the Uri is valid. This parameter shall be set to PT0S to indicate that this stream URI is indefinitely valid even if the profile changes.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
@@ -3801,6 +3924,12 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 		<xs:sequence>
 			<xs:element name="XAddr" type="xs:anyURI"/>
 			<xs:element name="MetadataSearch" type="xs:boolean"/>
+			<xs:element name="NLSearch" type="xs:boolean" minOccurs="0">
+				<xs:annotation><xs:documentation>Indicates support for natural language based search.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="ImageSearch" type="xs:boolean" minOccurs="0">
+				<xs:annotation><xs:documentation>Indicates support for image based search.</xs:documentation></xs:annotation>
+			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>
@@ -4385,8 +4514,8 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 					<xs:documentation>
 					'Bistable' or 'Monostable'
 					<ul>
-							<li>Bistable – After setting the state, the relay remains in this state.</li>
-							<li>Monostable – After setting the state, the relay returns to its idle state after the specified time.</li>
+							<li>Bistable - After setting the state, the relay remains in this state.</li>
+							<li>Monostable - After setting the state, the relay returns to its idle state after the specified time.</li>
 						</ul>
 					</xs:documentation>
 				</xs:annotation>
@@ -4634,7 +4763,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 					<xs:element name="PanTiltLimits" type="tt:PanTiltLimits" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>
-                The Pan/Tilt limits element should be present for a PTZ Node that supports an absolute Pan/Tilt. If the element is present it signals the support for configurable Pan/Tilt limits. If limits are enabled, the Pan/Tilt movements shall always stay within the specified range. The Pan/Tilt limits are disabled by setting the limits to –INF or +INF.
+                The Pan/Tilt limits element should be present for a PTZ Node that supports an absolute Pan/Tilt. If the element is present it signals the support for configurable Pan/Tilt limits. If limits are enabled, the Pan/Tilt movements shall always stay within the specified range. The Pan/Tilt limits are disabled by setting the limits to -INF or +INF.
               </xs:documentation>
 						</xs:annotation>
 					</xs:element>
@@ -4885,7 +5014,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="AbsolutePanTiltPositionSpace" type="tt:Space2DDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-            The Generic Pan/Tilt Position space is provided by every PTZ node that supports absolute Pan/Tilt, since it does not relate to a specific physical range. 
+            The Generic Pan/Tilt Position space is provided by every PTZ node that supports absolute Pan/Tilt, since it does not relate to a specific physical range.
 			Instead, the range should be defined as the full range of the PTZ unit normalized to the range -1 to 1 resulting in the following space description.
           </xs:documentation>
 				</xs:annotation>
@@ -4893,8 +5022,8 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="AbsoluteZoomPositionSpace" type="tt:Space1DDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-            The Generic Zoom Position Space is provided by every PTZ node that supports absolute Zoom, since it does not relate to a specific physical range. 
-			Instead, the range should be defined as the full range of the Zoom normalized to the range 0 (wide) to 1 (tele). 
+            The Generic Zoom Position Space is provided by every PTZ node that supports absolute Zoom, since it does not relate to a specific physical range.
+			Instead, the range should be defined as the full range of the Zoom normalized to the range 0 (wide) to 1 (tele).
 			There is no assumption about how the generic zoom range is mapped to magnification, FOV or other physical zoom dimension.
           </xs:documentation>
 				</xs:annotation>
@@ -4902,8 +5031,8 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="RelativePanTiltTranslationSpace" type="tt:Space2DDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-            The Generic Pan/Tilt translation space is provided by every PTZ node that supports relative Pan/Tilt, since it does not relate to a specific physical range. 
-			Instead, the range should be defined as the full positive and negative translation range of the PTZ unit normalized to the range -1 to 1, 
+            The Generic Pan/Tilt translation space is provided by every PTZ node that supports relative Pan/Tilt, since it does not relate to a specific physical range.
+			Instead, the range should be defined as the full positive and negative translation range of the PTZ unit normalized to the range -1 to 1,
 			where positive translation would mean clockwise rotation or movement in right/up direction resulting in the following space description.
           </xs:documentation>
 				</xs:annotation>
@@ -4911,9 +5040,9 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="RelativeZoomTranslationSpace" type="tt:Space1DDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-            The Generic Zoom Translation Space is provided by every PTZ node that supports relative Zoom, since it does not relate to a specific physical range. 
-			Instead, the corresponding absolute range should be defined as the full positive and negative translation range of the Zoom normalized to the range -1 to1, 
-			where a positive translation maps to a movement in TELE direction. The translation is signed to indicate direction (negative is to wide, positive is to tele). 
+            The Generic Zoom Translation Space is provided by every PTZ node that supports relative Zoom, since it does not relate to a specific physical range.
+			Instead, the corresponding absolute range should be defined as the full positive and negative translation range of the Zoom normalized to the range -1 to1,
+			where a positive translation maps to a movement in TELE direction. The translation is signed to indicate direction (negative is to wide, positive is to tele).
 			There is no assumption about how the generic zoom range is mapped to magnification, FOV or other physical zoom dimension. This results in the following space description.
           </xs:documentation>
 				</xs:annotation>
@@ -4921,8 +5050,8 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="ContinuousPanTiltVelocitySpace" type="tt:Space2DDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-            The generic Pan/Tilt velocity space shall be provided by every PTZ node, since it does not relate to a specific physical range. 
-			Instead, the range should be defined as a range of the PTZ unit’s speed normalized to the range -1 to 1, where a positive velocity would map to clockwise 
+            The generic Pan/Tilt velocity space shall be provided by every PTZ node, since it does not relate to a specific physical range.
+			Instead, the range should be defined as a range of the PTZ unit's speed normalized to the range -1 to 1, where a positive velocity would map to clockwise
 			rotation or movement in the right/up direction. A signed speed can be independently specified for the pan and tilt component resulting in the following space description.
           </xs:documentation>
 				</xs:annotation>
@@ -4930,7 +5059,7 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="ContinuousZoomVelocitySpace" type="tt:Space1DDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-            The generic zoom velocity space specifies a zoom factor velocity without knowing the underlying physical model. The range should be normalized from -1 to 1, 
+            The generic zoom velocity space specifies a zoom factor velocity without knowing the underlying physical model. The range should be normalized from -1 to 1,
 			where a positive velocity would map to TELE direction. A generic zoom velocity space description resembles the following.
           </xs:documentation>
 				</xs:annotation>
@@ -4938,8 +5067,8 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="PanTiltSpeedSpace" type="tt:Space1DDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-            The speed space specifies the speed for a Pan/Tilt movement when moving to an absolute position or to a relative translation. 
-			In contrast to the velocity spaces, speed spaces do not contain any directional information. The speed of a combined Pan/Tilt 
+            The speed space specifies the speed for a Pan/Tilt movement when moving to an absolute position or to a relative translation.
+			In contrast to the velocity spaces, speed spaces do not contain any directional information. The speed of a combined Pan/Tilt
 			movement is represented by a single non-negative scalar value.
           </xs:documentation>
 				</xs:annotation>
@@ -4947,8 +5076,8 @@ decoding .A decoder shall decode every data it receives (according to its capabi
 			<xs:element name="ZoomSpeedSpace" type="tt:Space1DDescription" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>
-            The speed space specifies the speed for a Zoom movement when moving to an absolute position or to a relative translation. 
-			In contrast to the velocity spaces, speed spaces do not contain any directional information. 
+            The speed space specifies the speed for a Zoom movement when moving to an absolute position or to a relative translation.
+			In contrast to the velocity spaces, speed spaces do not contain any directional information.
           </xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -5496,8 +5625,8 @@ If set to 0.0, infinity will be used.</xs:documentation>
 					<xs:documentation>
 					Exposure Mode
 					<ul>
-							<li>Auto – Enabled the exposure algorithm on the NVT.</li>
-							<li>Manual – Disabled exposure algorithm on the NVT.</li>
+							<li>Auto - Enabled the exposure algorithm on the NVT.</li>
+							<li>Manual - Disabled exposure algorithm on the NVT.</li>
 						</ul>
 					</xs:documentation>
 				</xs:annotation>
@@ -6181,8 +6310,8 @@ If set to 0.0, infinity will be used.</xs:documentation>
 					<xs:documentation>
 				Exposure Mode
 				<ul>
-							<li>Auto – Enabled the exposure algorithm on the device.</li>
-							<li>Manual – Disabled exposure algorithm on the device.</li>
+							<li>Auto - Enabled the exposure algorithm on the device.</li>
+							<li>Manual - Disabled exposure algorithm on the device.</li>
 						</ul>
 					</xs:documentation>
 				</xs:annotation>
@@ -6552,8 +6681,8 @@ If set to 0.0, infinity will be used.</xs:documentation>
 					<xs:documentation>
 				Exposure Mode
 				<ul>
-							<li>Auto – Enabled the exposure algorithm on the device.</li>
-							<li>Manual – Disabled exposure algorithm on the device.</li>
+							<li>Auto - Enabled the exposure algorithm on the device.</li>
+							<li>Manual - Disabled exposure algorithm on the device.</li>
 						</ul>
 					</xs:documentation>
 				</xs:annotation>
@@ -6945,7 +7074,7 @@ If set to 0.0, infinity will be used.</xs:documentation>
 					<xs:sequence>
 						<xs:any namespace="##any" processContents="lax">
 							<xs:annotation>
-								<xs:documentation>XML tree contiaing the element value as defined in the corresponding description.</xs:documentation>
+								<xs:documentation>XML tree containing the element value as defined in the corresponding description.</xs:documentation>
 							</xs:annotation>
 						</xs:any>
 					</xs:sequence>
@@ -7062,21 +7191,21 @@ If set to 0.0, infinity will be used.</xs:documentation>
 		<xs:sequence>
 			<xs:element name="Point" type="tt:Vector" minOccurs="2" maxOccurs="unbounded"/>
 		</xs:sequence>
-<!--		<xs:attribute name='dummy'/> uncomment for compilation with Visual Studio --> 
+<!--		<xs:attribute name='dummy'/> uncomment for compilation with Visual Studio -->
 	</xs:complexType>
 	<xs:element name="Polyline" type="tt:Polyline"/>
 	<!--===============================-->
-	
+
 	<xs:simpleType name="Direction">
 		<xs:union memberTypes="tt:ExtendedDirection"/>
 	</xs:simpleType>
-	
+
 	<xs:simpleType name="ExtendedDirection">
 		<xs:annotation>
 			<xs:documentation>Entering represents object coming into the polygon boundary.</xs:documentation>
 			<xs:documentation>Exiting represents object going out of the polygon boundary.</xs:documentation>
 			<xs:documentation>Approaching represents distance of object to camera sensor decreasing over time.</xs:documentation>
-			<xs:documentation>Departing represents distance of object to camera sensor increasing over time.</xs:documentation>		
+			<xs:documentation>Departing represents distance of object to camera sensor increasing over time.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="Left"/>
@@ -7089,7 +7218,7 @@ If set to 0.0, infinity will be used.</xs:documentation>
 			<xs:enumeration value="Departing"/>
 		</xs:restriction>
 	</xs:simpleType>
-	
+
 	<!--    Analytics Configuration    -->
 	<!--===============================-->
 	<xs:complexType name="AnalyticsEngineConfiguration">
@@ -7878,6 +8007,76 @@ and sample rate. </xs:documentation>
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
+	<!-- FindObjectImageResultList -->
+	<xs:complexType name="FindObjectImageResultList">
+		<xs:sequence>
+			<xs:element name="SearchState" type="tt:SearchState">
+				<xs:annotation>
+					<xs:documentation>The state of the search when the result is returned. Indicates if there can be more results, or if the search is completed.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Result" type="tt:FindObjectImageResult" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation><xs:documentation>A FindObjectImageResult structure for each found set of image matching the search.</xs:documentation></xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!-- FindObjectImageResult -->
+	<xs:complexType name="FindObjectImageResult">
+		<xs:sequence>
+			<xs:element name="ObjectUUID" type="xs:string">
+				<xs:annotation><xs:documentation>Object unique identifier.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="TargetImageURI" type="xs:anyURI">
+				<xs:annotation><xs:documentation>The URI of the detected target object image stored in the Target Image repository (LocalStorage format).</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="Time" type="xs:dateTime">
+				<xs:annotation><xs:documentation>The time when the target was found. Users can use this as a reference point to search records that occurred before and after this specific time point.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="Similarity" type="xs:float">
+				<xs:annotation><xs:documentation>It represents the similarity between two vectors, which is used to measure the similarity of the directions of the vectors. The closer the value is to 1, the higher the similarity; the closer the value is to 0, the lower the similarity.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="RecordingToken" type="tt:RecordingReference">
+				<xs:annotation><xs:documentation>The recording where this result was found.</xs:documentation></xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>	
+
+	<!-- FindNLSearchResultList -->
+	<xs:complexType name="FindNLSearchResultList">
+		<xs:sequence>
+			<xs:element name="SearchState" type="tt:SearchState">
+				<xs:annotation>
+					<xs:documentation>The state of the search when the result is returned. Indicates if there can be more results, or if the search is completed.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Result" type="tt:FindNLSearchResult" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation><xs:documentation>A FindNLSearchResult structure for each found set of image matching the search.</xs:documentation></xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!-- FindNLSearchResult -->
+	<xs:complexType name="FindNLSearchResult">
+		<xs:sequence>
+			<xs:element name="ObjectUUID" type="xs:string">
+				<xs:annotation><xs:documentation>Object unique identifier.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="TargetImageURI" type="xs:anyURI">
+				<xs:annotation><xs:documentation>The URI of the detected target object image stored in the Target Image repository (LocalStorage format).</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="Time" type="xs:dateTime">
+				<xs:annotation><xs:documentation>The time when the target was found. Users can use this as a reference point to search records that occurred before and after this specific time point.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="Similarity" type="xs:float">
+				<xs:annotation><xs:documentation>It represents the similarity between two vectors, which is used to measure the similarity of the directions of the vectors. The closer the value is to 1, the higher the similarity; the closer the value is to 0, the lower the similarity.</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="RecordingToken" type="tt:RecordingReference">
+				<xs:annotation><xs:documentation>The recording where this result was found.</xs:documentation></xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>	
+
 	<!--===============================-->
 	<xs:simpleType name="SearchState">
 		<xs:restriction base="xs:string">
@@ -7968,6 +8167,11 @@ and sample rate. </xs:documentation>
 					<xs:documentation>URI provided by the service supplying data to be recorded. A device shall support at least 128 characters.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="VideoSourceToken" type="tt:ReferenceToken" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The video source token of all recordings that will use this configuration.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first Vendor then ONVIF -->
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>
@@ -8020,9 +8224,17 @@ and sample rate. </xs:documentation>
 			<xs:element name="KeyRotationDuration" type="xs:duration" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>
-					Frequency at which the device shall generate a new key to encrypt a new segment. 
-					If not specified, key rotation is disabled. 
+					Frequency at which the device shall generate a new key to encrypt a new segment.
+					If not specified, key rotation is disabled.
 					KeyRotationDuration must be a positive duration value.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInfo" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Additional information related to the asymmetric encryption that will be used as
+						part of the key encryption. A device shall support at least 256 characters.
+					</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
@@ -8033,13 +8245,13 @@ and sample rate. </xs:documentation>
 		<xs:sequence>
 			<xs:element name="KID" type="xs:string" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
-					<xs:documentation>Key ID of the associated key for encryption. This parameter is ignored when AsymmetricEncryption is configured.</xs:documentation>
+					<xs:documentation>Key ID of the associated key for encryption, formatted as a UUID according to RFC 9562 Section 4. The client shall omit this parameter when AsymmetricEncryption is configured.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Key" type="xs:hexBinary" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>
-						Key for encrypting content. This parameter is ignored when AsymmetricEncryption is configured.
+						Key for encrypting content. The client shall omit this parameter when AsymmetricEncryption is configured.
 						The device shall not include this parameter when reading.
 					</xs:documentation>
 				</xs:annotation>
@@ -8131,10 +8343,40 @@ and sample rate. </xs:documentation>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
+			<xs:element name="StorageStrategy" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Strategy to be used on how to store recordings, see tt:StorageStrategy for allowed values. If undefined, defaults to External.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 		</xs:sequence>
 		<xs:anyAttribute processContents="lax"/>
 	</xs:complexType>
+	<xs:simpleType name="StorageStrategy">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="External">
+				<xs:annotation>
+					<xs:documentation>Indicates that device must record to the storage defined by the StorageConfiguration token.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Local">
+				<xs:annotation>
+					<xs:documentation>
+						Indicates that device must record on its local storage and can export recorded data to the external 
+						storage using ExportRecordedSegments.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Both">
+				<xs:annotation>
+					<xs:documentation>
+						Indicates that device must record on both local storage and external storage and locally recorded data can
+						be exported if connectivity issue prevented export to external storage during normal operation.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
 	<!--===============================-->
 	<xs:simpleType name="RecordingStatus">
 		<xs:restriction base="xs:string">
@@ -8362,12 +8604,12 @@ and sample rate. </xs:documentation>
 			</xs:element>
 			<xs:element name="MaximumRetentionTime" type="xs:duration">
 				<xs:annotation>
-					<xs:documentation>Sspecifies the maximum time that data in any track within the
+					<xs:documentation>Specifies the maximum time that data in any track within the
 				recording shall be stored. The device shall delete any data older than the maximum retention
 				time. Such data shall not be accessible anymore. If the MaximumRetentionPeriod is set to 0,
 				the device shall not limit the retention time of stored data, except by resource constraints.
 				Whatever the value of MaximumRetentionTime, the device may automatically delete
-				recordings to free up storage space for new recordings.</xs:documentation>
+				recordings to free up storage space for new recordings. This parameter has no effect on the data stored in external targets for e.g. Object Storage.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Target" type="tt:RecordingTargetConfiguration" minOccurs="0">
@@ -8384,8 +8626,8 @@ and sample rate. </xs:documentation>
 		<xs:sequence>
 			<xs:element name="TrackType" type="tt:TrackType">
 				<xs:annotation>
-					<xs:documentation>Type of the track. It shall be equal to the strings “Video”,
-				“Audio” or “Metadata”. The track shall only be able to hold data of that type.</xs:documentation>
+					<xs:documentation>Type of the track. It shall be equal to the strings "Video",
+				"Audio" or "Metadata". The track shall only be able to hold data of that type.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Description" type="tt:Description">
@@ -8459,7 +8701,7 @@ and sample rate. </xs:documentation>
 				<xs:annotation>
 					<xs:documentation>The mode of the job. If it is idle, nothing shall happen. If it is active, the device shall try
 				to obtain data from the receivers. A client shall use GetRecordingJobState to determine if data transfer is really taking place.<br/>
-				The only valid values for Mode shall be “Idle” and “Active”.</xs:documentation>
+				The only valid values for Mode shall be "Idle" and "Active".</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Priority" type="xs:int">
@@ -8484,8 +8726,8 @@ and sample rate. </xs:documentation>
 		</xs:sequence>
 		<xs:attribute name="ScheduleToken">
 			<xs:annotation>
-				<xs:documentation>This attribute adds an additional requirement for activating the recording job. 
-				If this optional field is provided the job shall only record if the schedule exists and is active. 
+				<xs:documentation>This attribute adds an additional requirement for activating the recording job.
+				If this optional field is provided the job shall only record if the schedule exists and is active.
 				</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
@@ -8537,8 +8779,8 @@ and sample rate. </xs:documentation>
 				is determined by the attribute Type in the SourceToken structure. If Type is
 				http://www.onvif.org/ver10/schema/Receiver, the token is a ReceiverReference. In this case
 				the device shall receive the data over the network. If Type is
-				http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, instructing the
-				device to obtain data from a profile that exists on the local device.</xs:documentation>
+				http://www.onvif.org/ver10/schema/Profile, the token identifies a media profile, provisioned via the ONVIF Media Service or the ONVIF Media2 Service,
+				instructing the device to obtain data from a profile that exists on the local device.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="AutoCreateReceiver" type="xs:boolean" minOccurs="0">
@@ -8666,7 +8908,7 @@ and sample rate. </xs:documentation>
 			<xs:element name="State" type="tt:RecordingJobState">
 				<xs:annotation>
 					<xs:documentation>Provides the job state of the track. The valid
-				values of state shall be “Idle”, “Active” and “Error”. If state equals “Error”, the Error field may be filled in with an implementation defined value.</xs:documentation>
+				values of state shall be "Idle", "Active" and "Error". If state equals "Error", the Error field may be filled in with an implementation defined value.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##targetNamespace" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
@@ -8948,7 +9190,7 @@ and sample rate. </xs:documentation>
 			<xs:annotation>
 			<xs:documentation>Indicates audio class label</xs:documentation>
 			</xs:annotation>
-		</xs:element> 
+		</xs:element>
  		<xs:element name="Likelihood" type="xs:float">
 			<xs:annotation>
 			<xs:documentation>A likelihood/probability that the corresponding audio event belongs to this class. The sum of the likelihoods shall NOT exceed 1</xs:documentation>
@@ -9468,9 +9710,13 @@ and sample rate. </xs:documentation>
 	<!--=========================================-->
 	<!--  End, ExportRecordedDataState           -->
 	<!--=========================================-->
-	
+<xs:element name="FindObjectImageResultList" type="tt:FindObjectImageResultList"/>
+<xs:element name="FindObjectImageResult" type="tt:FindObjectImageResult"/>
+<xs:element name="FindNLSearchResultList" type="tt:FindNLSearchResultList"/>
+<xs:element name="FindNLSearchResult" type="tt:FindNLSearchResult"/>
+
 <xs:element name="PolygonOptions" type="tt:PolygonOptions"/>
- 
+
 <xs:complexType name="PolygonOptions">
 	<xs:sequence>
 		<xs:element name="RectangleOnly" type="xs:boolean" minOccurs="0">

--- a/onvif/wsdl/ver10/search.wsdl
+++ b/onvif/wsdl/ver10/search.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-Copyright (c) 2008-2014 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+Copyright (c) 2008-2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 
 Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 
@@ -10,7 +10,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tse="http://www.onvif.org/ver10/search/wsdl" targetNamespace="http://www.onvif.org/ver10/search/wsdl">
 	<wsdl:types>
-		<xs:schema targetNamespace="http://www.onvif.org/ver10/search/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="2.4.2">
+		<xs:schema targetNamespace="http://www.onvif.org/ver10/search/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../ver10/schema/onvif.xsd"/>
 			<!--  Message Request/Responses elements  -->
 			<!--===============================-->
@@ -37,6 +37,8 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				</xs:sequence>
 				<xs:attribute name="MetadataSearch" type="xs:boolean"/>
 				<xs:attribute name="GeneralStartEvents" type="xs:boolean"><xs:annotation><xs:documentation> Indicates support for general virtual property events in the FindEvents method.</xs:documentation></xs:annotation></xs:attribute>
+				<xs:attribute name="NLSearch" type="xs:boolean"><xs:annotation><xs:documentation>Indicates support for natural language based search.</xs:documentation></xs:annotation></xs:attribute>
+				<xs:attribute name="ImageSearch" type="xs:boolean"><xs:annotation><xs:documentation>Indicates support for image based search.</xs:documentation></xs:annotation></xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<xs:element name="Capabilities" type="tse:Capabilities"/>
@@ -117,7 +119,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<!--===============================-->
 			<xs:element name="GetRecordingSearchResults">
 				<xs:annotation>
-					<xs:documentation>Gets results from a particular recording listingession.</xs:documentation>
+					<xs:documentation>Gets results from a particular recording listing session.</xs:documentation>
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
@@ -444,7 +446,146 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<!--===============================-->
+			
+			<!-- Define SearchImageByNL -->
+			<xs:element name="SearchImageByNLRequest">
+				<xs:annotation>
+					<xs:documentation>Starts a search session and specifies the search parameters.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="StartPoint" type="xs:dateTime">
+							<xs:annotation><xs:documentation>Start time for the search.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="EndPoint" type="xs:dateTime" minOccurs="0">
+							<xs:annotation><xs:documentation>The point of time where the search will stop. If EndPoint is omitted, the search will continue up to the latest recorded data available on the device.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="RecordingToken" type="tt:RecordingReference" minOccurs="0">
+							<xs:annotation><xs:documentation>Token for the recording to search.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="Text" type="xs:string">
+							<xs:annotation><xs:documentation>Natural language description for the search (e.g., "person with red hat").</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="Similarity" type="xs:float" minOccurs="0">
+							<xs:annotation><xs:documentation>It represents the similarity between two vectors, which is used to measure the similarity of the directions of the vectors. The closer the value is to 1, the higher the similarity; the closer the value is to 0, the lower the similarity.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="MaxMatches" type="xs:int" minOccurs="0">
+							<xs:annotation><xs:documentation>Maximum number of matches to return in the response.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="KeepAliveTime" type="xs:duration">
+							<xs:annotation><xs:documentation>The time the search session will be kept alive after responding to this and subsequent requests.</xs:documentation></xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SearchImageByNLResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SearchToken" type="tt:JobToken">
+							<xs:annotation><xs:documentation>A unique reference to the search session created by this request.</xs:documentation></xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>	
+
+			<!-- Define GetNLSearchResults -->
+			<xs:element name="GetNLSearchResultsRequest">
+				<xs:annotation>
+					<xs:documentation>Gets results from a particular search session.</xs:documentation>
+				</xs:annotation>			
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SearchToken" type="tt:JobToken">
+							<xs:annotation><xs:documentation>The search session to get results from.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="MinResults" type="xs:int" minOccurs="0">
+							<xs:annotation><xs:documentation>The minimum number of results to return in one response.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="MaxResults" type="xs:int" minOccurs="0">
+							<xs:annotation><xs:documentation>The maximum number of results to return in one response.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="WaitTime" type="xs:duration" minOccurs="0">
+							<xs:annotation><xs:documentation>The maximum time before responding to the request, even if the MinResults parameter is not fulfilled.</xs:documentation></xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="GetNLSearchResultsResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ResultList" type="tt:FindNLSearchResultList" />
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+
+			<!-- Define SearchImageByImage -->
+			<xs:element name="SearchImageByImageRequest">
+				<xs:annotation>
+					<xs:documentation>Starts a search session and specifies the search parameters.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="StartPoint" type="xs:dateTime">
+							<xs:annotation><xs:documentation>Start time for the search.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="EndPoint" type="xs:dateTime" minOccurs="0">
+							<xs:annotation><xs:documentation>The point of time where the search will stop. If EndPoint is omitted, the search will continue up to the latest recorded data available on the device.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="RecordingToken" type="tt:RecordingReference" minOccurs="0">
+							<xs:annotation><xs:documentation>Token for the recording to search.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="TargetImageURI" type="xs:anyURI" minOccurs="0">
+							<xs:annotation><xs:documentation>Exactly one of TargetImageURI or TargetImageData shall be provided. If both are provided, the device shall use TargetImageData. If neither is provided, the device shall respond with an InvalidArgVal fault. The URI of the detected target object image stored in the Target Image repository (LocalStorage format).</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="TargetImageData" type="xs:base64Binary" minOccurs="0">
+							<xs:annotation><xs:documentation>Exactly one of TargetImageURI or TargetImageData shall be provided. If both are provided, the device shall use TargetImageData. If neither is provided, the device shall respond with an InvalidArgVal fault. Base64-encoded target object image used for visual search.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="MaxMatches" type="xs:int" minOccurs="0">
+							<xs:annotation><xs:documentation>Maximum number of matches to return in the response.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="KeepAliveTime" type="xs:duration">
+							<xs:annotation><xs:documentation>The time the search session will be kept alive after responding to this and subsequent requests.</xs:documentation></xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="SearchImageByImageResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SearchToken" type="tt:JobToken">
+							<xs:annotation><xs:documentation>A unique reference to the search session created by this request.</xs:documentation></xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+
+			<!-- Define GetImageSearchResults -->
+			<xs:element name="GetImageSearchResultsRequest">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SearchToken" type="tt:JobToken">
+							<xs:annotation><xs:documentation>The search session to get results from.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="MinResults" type="xs:int" minOccurs="0">
+							<xs:annotation><xs:documentation>The minimum number of results to return in one response.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="MaxResults" type="xs:int" minOccurs="0">
+							<xs:annotation><xs:documentation>The maximum number of results to return in one response.</xs:documentation></xs:annotation>
+						</xs:element>
+						<xs:element name="WaitTime" type="xs:duration" minOccurs="0">
+							<xs:annotation><xs:documentation>The maximum time before responding to the request, even if the MinResults parameter is not fulfilled.</xs:documentation></xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+
+			<xs:element name="GetImageSearchResultsResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ResultList" type="tt:FindObjectImageResultList" />
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>	
 			<!--===============================-->
 		</xs:schema>
 	</wsdl:types>
@@ -531,6 +672,30 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	</wsdl:message>
 	<wsdl:message name="GetMetadataSearchResultsResponse">
 		<wsdl:part name="parameters" element="tse:GetMetadataSearchResultsResponse"/>
+	</wsdl:message>
+	<wsdl:message name="SearchImageByNLRequest">
+		<wsdl:part name="parameters" element="tse:SearchImageByNLRequest"/>
+	</wsdl:message>
+	<wsdl:message name="SearchImageByNLResponse">
+		<wsdl:part name="parameters" element="tse:SearchImageByNLResponse"/>
+	</wsdl:message>
+	<wsdl:message name="GetNLSearchResultsRequest">
+		<wsdl:part name="parameters" element="tse:GetNLSearchResultsRequest"/>
+	</wsdl:message>
+	<wsdl:message name="GetNLSearchResultsResponse">
+		<wsdl:part name="parameters" element="tse:GetNLSearchResultsResponse"/>
+	</wsdl:message>
+	<wsdl:message name="SearchImageByImageRequest">
+		<wsdl:part name="parameters" element="tse:SearchImageByImageRequest"/>
+	</wsdl:message>
+	<wsdl:message name="SearchImageByImageResponse">
+		<wsdl:part name="parameters" element="tse:SearchImageByImageResponse"/>
+	</wsdl:message>
+	<wsdl:message name="GetImageSearchResultsRequest">
+		<wsdl:part name="parameters" element="tse:GetImageSearchResultsRequest"/>
+	</wsdl:message>
+	<wsdl:message name="GetImageSearchResultsResponse">
+		<wsdl:part name="parameters" element="tse:GetImageSearchResultsResponse"/>
 	</wsdl:message>
 	<wsdl:portType name="SearchPort">
 		<!--===============================-->
@@ -732,6 +897,31 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 			<wsdl:input message="tse:GetMetadataSearchResultsRequest"/>
 			<wsdl:output message="tse:GetMetadataSearchResultsResponse"/>
 		</wsdl:operation>
+		<!-- SearchImageByNL operation -->
+		<wsdl:operation name="SearchImageByNL">
+			<wsdl:documentation>Starts a natural language search session and specifies the search parameters.</wsdl:documentation>
+			<wsdl:input message="tse:SearchImageByNLRequest"/>
+			<wsdl:output message="tse:SearchImageByNLResponse"/>
+		</wsdl:operation>
+		<!-- GetNLSearchResults operation -->
+		<wsdl:operation name="GetNLSearchResults">
+			<wsdl:documentation>Gets results from a natural language search session.</wsdl:documentation>
+			<wsdl:input message="tse:GetNLSearchResultsRequest"/>
+			<wsdl:output message="tse:GetNLSearchResultsResponse"/>
+		</wsdl:operation>	
+		<!-- SearchImageByImage operation -->
+		<wsdl:operation name="SearchImageByImage">
+			<wsdl:documentation>Starts an image-based search session and specifies the search parameters.</wsdl:documentation>
+			<wsdl:input message="tse:SearchImageByImageRequest"/>
+			<wsdl:output message="tse:SearchImageByImageResponse"/>
+		</wsdl:operation>
+
+		<!-- GetImageSearchResults operation -->
+		<wsdl:operation name="GetImageSearchResults">
+			<wsdl:documentation>Gets results from an image-based search session.</wsdl:documentation>
+			<wsdl:input message="tse:GetImageSearchResultsRequest"/>
+			<wsdl:output message="tse:GetImageSearchResultsResponse"/>
+		</wsdl:operation>
 	</wsdl:portType>
 	<wsdl:binding name="SearchBinding" type="tse:SearchPort">
 		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
@@ -878,5 +1068,47 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<!--===============================-->
 		<!--===============================-->
+
+		<!-- SearchImageByNL operation -->
+		<wsdl:operation name="SearchImageByNL">
+			<soap:operation soapAction="http://www.onvif.org/ver10/search/wsdl/SearchImageByNL"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	    <!-- GetNLSearchResults operation -->
+		<wsdl:operation name="GetNLSearchResults">
+			<soap:operation soapAction="http://www.onvif.org/ver10/search/wsdl/GetNLSearchResults"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>	
+		<!-- SearchImageByImage operation -->
+		<wsdl:operation name="SearchImageByImage">
+			<soap:operation soapAction="http://www.onvif.org/ver10/search/wsdl/SearchImageByImage"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+
+		<!-- GetImageSearchResults operation -->
+		<wsdl:operation name="GetImageSearchResults">
+			<soap:operation soapAction="http://www.onvif.org/ver10/search/wsdl/GetImageSearchResults"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
 	</wsdl:binding>
 </wsdl:definitions>

--- a/onvif/wsdl/ver10/uplink/wsdl/uplink.wsdl
+++ b/onvif/wsdl/ver10/uplink/wsdl/uplink.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../../../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-Copyright (c) 2008-2025 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+Copyright (c) 2008-2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 
 Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 
@@ -10,7 +10,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tup="http://www.onvif.org/ver10/uplink/wsdl" targetNamespace="http://www.onvif.org/ver10/uplink/wsdl">
 	<wsdl:types>
-		<xs:schema targetNamespace="http://www.onvif.org/ver10/uplink/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="25.12">
+		<xs:schema targetNamespace="http://www.onvif.org/ver10/uplink/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../../schema/onvif.xsd"/>
 			<!--  Message Request/Responses elements  -->
 			<!--===============================-->

--- a/onvif/wsdl/ver20/media/wsdl/media.wsdl
+++ b/onvif/wsdl/ver20/media/wsdl/media.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../../../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-Copyright (c) 2008-2025 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+Copyright (c) 2008-2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 
 Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 
@@ -10,7 +10,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tr2="http://www.onvif.org/ver20/media/wsdl" targetNamespace="http://www.onvif.org/ver20/media/wsdl">
 	<wsdl:types>
-		<xs:schema targetNamespace="http://www.onvif.org/ver20/media/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="25.12">
+		<xs:schema targetNamespace="http://www.onvif.org/ver20/media/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../../../ver10/schema/onvif.xsd"/>
 			<!--  Message Request/Responses elements  -->
 			<!--===============================-->
@@ -41,11 +41,6 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:element name="StreamingCapabilities" type="tr2:StreamingCapabilities">
 						<xs:annotation>
 							<xs:documentation>Streaming capabilities.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="MediaSigningCapabilities" type="tr2:MediaSigningCapabilities" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>Media signing capabilities.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="AudioClipCapabilities" type="tr2:AudioClipCapabilities" minOccurs="0">
@@ -100,6 +95,11 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:attribute name="WebRTC" type="xs:int">
 					<xs:annotation>
 						<xs:documentation>Indicates number of supported WebRTC configurations.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="WebRTC_codecs" type="tt:StringList">
+					<xs:annotation>
+						<xs:documentation>List of supported video and audio media types as defined by IANA. E.g. "video/H264 audio/opus".</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 				<xs:anyAttribute processContents="lax"/>
@@ -188,20 +188,15 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<!--===============================-->
-			<xs:complexType name="MediaSigningCapabilities">
-				<xs:sequence>
-					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
-				</xs:sequence>
-				<xs:attribute name="MediaSigningSupported" type="xs:boolean">
-					<xs:annotation>
-						<xs:documentation>Indicates whether the device supports signing of media according to the Media Signing Specification.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-				<xs:anyAttribute processContents="lax"/>
-			</xs:complexType>
-			<!--===============================-->
 			<xs:complexType name="AudioClipCapabilities">
 				<xs:sequence>
+                  <!--==============TTS Capability=================-->
+                  <xs:element name="TTSCapabilities" type="tr2:TTSCapabilities" minOccurs="0">
+                     <xs:annotation>
+                        <xs:documentation>Indicates device has TTS capability.</xs:documentation>
+                     </xs:annotation>
+                  </xs:element>
+                 <!--=============================================-->
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
 				<xs:attribute name="MaxAudioClipLimit" type="xs:int">
@@ -222,6 +217,40 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
 			<!--===============================-->
+            <!--=============TTS Capability=================-->
+            <xs:complexType name="TTSCapabilities">
+				<xs:sequence>
+                   <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+                </xs:sequence>
+				<xs:attribute name="MaxContentLength" type="xs:int">
+                   <xs:annotation>
+                       <xs:documentation> Indicates the maximum length of content of a text for device to convert to an audio clip.</xs:documentation>
+                   </xs:annotation>
+                 </xs:attribute>
+                 <xs:attribute name="TTSLanguage" type="tt:StringAttrList">
+                    <xs:annotation>
+                        <xs:documentation> 
+                            List of supported languages. Uses ISO 639-1 alpha-2 language codes, such as"en" for English. See <a href="https://www.loc.gov/standards/iso639-2/php/English_list.php">Codes for the Representation of Names of Languages</a>.
+                            Optionally combined with ISO 3166-1 alpha-2 country codes using the "language-country" format to specify regional variations, such as"en-US" for American English. For country codes, see <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Country Codes</a>.
+                        </xs:documentation>
+                   </xs:annotation>
+                 </xs:attribute>
+                 <xs:attribute name="TTSVoiceType" type="tt:StringAttrList">
+                   <xs:annotation>
+                        <xs:documentation> List of supported voice types. See tr2: TTSVoiceType.</xs:documentation>     
+                   </xs:annotation>
+                 </xs:attribute>
+                <xs:anyAttribute processContents="lax"/>
+            </xs:complexType>
+          <!--=============TTS Voice Type==================-->
+          <xs:simpleType name="TTSVoiceType">
+              <xs:restriction base="xs:string">
+              <xs:enumeration value="male"/>
+              <xs:enumeration value="female"/>
+              </xs:restriction>
+          </xs:simpleType>
+         <!--==============TTS End===============-->
+         <!--====================================-->
 			<xs:simpleType name="SupportedAudioClipFormat">
 				<xs:restriction base="xs:string">
 					<xs:enumeration value="audio/vnd.wave;codec=1"/>
@@ -804,7 +833,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					<xs:enumeration value="RtspMulticast"/>		<!-- RTSP streaming RTP as UDP Multicast. -->
 					<xs:enumeration value="RtspsUnicast"/>		<!-- Secure RTSP streaming SRTP as UDP Unicast. -->
 					<xs:enumeration value="RtspsMulticast"/>	<!-- Secure RTSP streaming SRTP as UDP Multicast. -->
-					<xs:enumeration value="RTSP"/>				<!-- RTSP streaming RTP over TCP. -->
+					<xs:enumeration value="RTSP"/>			<!-- RTSP streaming RTP over TCP. -->
 					<xs:enumeration value="RtspOverHttp"/>		<!-- Tunneling both the RTSP control channel and the RTP stream over HTTP or HTTPS. -->
 				</xs:restriction>
 			</xs:simpleType>
@@ -825,7 +854,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 				<xs:sequence>
 					<xs:element name="Encoding" type="xs:string">
 						<xs:annotation>
-					<xs:documentation>Video Media Subtype for the video format. For definitions see tt:VideoEncodingMimeNames and <a href="https://www.iana.org/assignments/media-types/media-types.xhtml#video"> IANA Media Types</a>.</xs:documentation>
+							<xs:documentation>Video Media Subtype for the video format. For definitions see tt:VideoEncodingMimeNames and <a href="https://www.iana.org/assignments/media-types/media-types.xhtml#video"> IANA Media Types</a>.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Number" type="xs:int">
@@ -1438,15 +1467,41 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:element>
 					<xs:element name="ScheduleToken" type="tt:ReferenceToken" minOccurs="0">
 					<xs:annotation>
-						<xs:documentation> Optional schedule token associated with the audio clip configuration. The audio clip should be played when the configured schedule is triggered.</xs:documentation>
+						<xs:documentation> Optional schedule token associated with the audio clip configuration. The audio clip shall be played when the configured schedule is triggered.</xs:documentation>
 					</xs:annotation>
 					</xs:element>					
 					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
 				</xs:sequence>
 				<xs:anyAttribute processContents="lax"/>
 			</xs:complexType>
-			
-			<!--===============================-->
+             <!--=========TTS Audio======================-->
+			 <xs:complexType name="TTSAudio">
+				<xs:sequence>					
+				 <xs:element name="Content" type="xs:string">
+                     <xs:annotation>
+                         <xs:documentation>Content of the audio clip.</xs:documentation>
+                     </xs:annotation>
+                 </xs:element>
+                 <xs:element name="Language" type="xs:string">
+                     <xs:annotation>
+                         <xs:documentation>
+                             The language that is supported by the device and used for TTS audio clip playback. 
+                             Uses ISO 639-1 alpha-2 language codes for definition, such as"en" for English. See <a href="https://www.loc.gov/standards/iso639-2/php/English_list.php">Codes for the Representation of Names of Languages</a>.
+                             Optionally combined with ISO 3166-1 alpha-2 country codes using the "language-country" format to specify regional variations, such as"en-US" for American English. For country codes, see <a href="https://www.iso.org/obp/ui/#search/code/">ISO 3166-1 Country Codes</a>.
+                         </xs:documentation>
+                     </xs:annotation>
+                 </xs:element>
+                 <xs:element name="VoiceType" type="xs:string">
+                     <xs:annotation>
+                         <xs:documentation>The voice type that is supported by the device and used for TTS audio clip playback. See tr2: TTSVoiceType.</xs:documentation>
+                     </xs:annotation>
+                 </xs:element>
+					<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>   <!-- first ONVIF then Vendor -->
+				</xs:sequence>
+				<xs:anyAttribute processContents="lax"/>
+			</xs:complexType>
+			<!--=========TTS Audio END=======================-->
+            <!--===============================-->
 			<xs:complexType name="GetAudioClipsResponseItem">
 				<xs:sequence>
 					<xs:element name="Token" type="tt:ReferenceToken">
@@ -1579,7 +1634,40 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-				
+        <!--==============TTS=================-->
+         <xs:element name="AddTTSAudioClip">
+				<xs:complexType>				
+					<xs:sequence>
+						<xs:element name="Token" type="tt:ReferenceToken" minOccurs="0">				
+							<xs:annotation>
+								<xs:documentation>Optional token associated with the audio clip.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Configuration" type="tr2:AudioClip">
+							<xs:annotation>
+								<xs:documentation>Audio clip configuration to add.</xs:documentation>
+							</xs:annotation>
+					    </xs:element>
+                        <xs:element name="TTSConfiguration" type="tr2:TTSAudio">
+                        <xs:annotation>
+                        <xs:documentation>The configuration for the TTS audio clip to add.</xs:documentation>
+                        </xs:annotation>
+                       </xs:element>        
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>			
+			<xs:element name="AddTTSAudioClipResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Token" type="tt:ReferenceToken">						
+							<xs:annotation>
+								<xs:documentation>Unique token assigned by device for the TTS audio clip.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>				
+			</xs:element>
+<!--==============TTS END=================-->
 			<xs:element name="DeleteAudioClip">
 				<xs:complexType>
 					<xs:sequence>
@@ -2018,6 +2106,14 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 	<wsdl:message name="AddAudioClipResponse">
 		<wsdl:part name="parameters" element="tr2:AddAudioClipResponse"/>
 	</wsdl:message>
+<!--==============TTS=================--> 
+    <wsdl:message name="AddTTSAudioClipRequest">
+		<wsdl:part name="parameters" element="tr2:AddTTSAudioClip"/>
+	</wsdl:message>
+	<wsdl:message name="AddTTSAudioClipResponse">
+		<wsdl:part name="parameters" element="tr2:AddTTSAudioClipResponse"/>
+	</wsdl:message>
+<!--==============================--> 
 	<wsdl:message name="SetAudioClipRequest">
 		<wsdl:part name="parameters" element="tr2:SetAudioClip"/>
 	</wsdl:message>
@@ -2266,7 +2362,9 @@ support streaming video data of such a profile.<br/>
 				 <ul>
 				 	<li>RtspUnicast		RTSP streaming RTP as UDP Unicast.</li>
 				 	<li>RtspMulticast	RTSP streaming RTP as UDP Multicast.</li>
-				 	<li>RTSP			RTSP streaming RTP over TCP.</li>
+				 	<li>RtspsUnicast	Secure RTSP streaming with SRTP as UDP Unicast.</li>
+				 	<li>RtspsMulticast	Secure RTSP streaming with SRTP as UDP Multicast.</li>
+				 	<li>RTSP		RTSP streaming RTP over TCP.</li>
 				 	<li>RtspOverHttp	Tunneling both the RTSP control channel and the RTP stream over HTTP or HTTPS.</li>
 				 </ul>
 				If a multicast stream is requested at least one of VideoEncoder2Configuration, AudioEncoder2Configuration and MetadataConfiguration shall have a valid multicast setting.<br/>
@@ -2412,6 +2510,13 @@ image will be updated automatically and independent from calls to GetSnapshotUri
 			<wsdl:input message="tr2:AddAudioClipRequest"/>
 			<wsdl:output message="tr2:AddAudioClipResponse"/>
 		</wsdl:operation>
+        <!--==============TTS=================--> 
+        <wsdl:operation name="AddTTSAudioClip">
+			<wsdl:documentation>This operation sends a text and its configuartion to device that supports TTS function, so that device could convert the text into an audio clip and play it according to audio clip Configuration and TTS Configuration.</wsdl:documentation>
+			<wsdl:input message="tr2:AddTTSAudioClipRequest"/>
+			<wsdl:output message="tr2:AddTTSAudioClipResponse"/>
+		</wsdl:operation>
+        <!--=============================--> 
 		<wsdl:operation name="SetAudioClip">
 			<wsdl:documentation>This operation modifies the existing audio clip configuration on the device.</wsdl:documentation>
 			<wsdl:input message="tr2:SetAudioClipRequest"/>
@@ -2940,6 +3045,17 @@ image will be updated automatically and independent from calls to GetSnapshotUri
 				<soap:body use="literal"/>
 			</wsdl:output>
 		</wsdl:operation>
+        <!--==============TTS=================-->
+        <wsdl:operation name="AddTTSAudioClip">
+			<soap:operation soapAction="http://www.onvif.org/ver20/media/wsdl/AddTTSAudioClip"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+       <!--=================================-->
 		<wsdl:operation name="SetAudioClip">
 			<soap:operation soapAction="http://www.onvif.org/ver20/media/wsdl/SetAudioClip"/>
 			<wsdl:input>

--- a/onvif/wsdl/ver20/ptz/wsdl/ptz.wsdl
+++ b/onvif/wsdl/ver20/ptz/wsdl/ptz.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="../../../ver20/util/onvif-wsdl-viewer.xsl"?>
 <!--
-Copyright (c) 2008-2020 by ONVIF: Open Network Video Interface Forum. All rights reserved.
+Copyright (c) 2008-2026 by ONVIF: Open Network Video Interface Forum. All rights reserved.
 
 Recipients of this document may copy, distribute, publish, or display this document so long as this copyright notice, license and disclaimer are retained with all copies of the document. No license is granted to modify this document.
 
@@ -10,7 +10,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 -->
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" name="PTZService" targetNamespace="http://www.onvif.org/ver20/ptz/wsdl">
 	<wsdl:types>
-		<xs:schema targetNamespace="http://www.onvif.org/ver20/ptz/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="25.12">
+		<xs:schema targetNamespace="http://www.onvif.org/ver20/ptz/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="26.06">
 			<xs:import namespace="http://www.onvif.org/ver10/schema" schemaLocation="../../../ver10/schema/onvif.xsd"/>
 			<!--  Message Request/Responses elements  -->
 			<!--===============================-->
@@ -1073,7 +1073,7 @@ IN NO EVENT WILL THE CORPORATION OR ITS MEMBERS OR THEIR AFFILIATES BE LIABLE FO
 		</wsdl:operation>
 		<wsdl:operation name="SetHomePosition">
 			<wsdl:documentation>Operation to save current position as the home position.
-				The SetHomePosition command returns with a failure if the “home” position is fixed and
+				The SetHomePosition command returns with a failure if the "home" position is fixed and
 				cannot be overwritten. If the SetHomePosition is successful, it is possible to recall the
 				Home Position with the GotoHomePosition command.</wsdl:documentation>
 			<wsdl:input message="tptz:SetHomePositionRequest"/>


### PR DESCRIPTION
- Update WSDL from remote https://github.com/onvif/specs (https://github.com/nirsimetri/onvif-python/commit/30b97b3131b56dc502f6984d6be19109a5c88959)
- Added implementation of `AddTTSAudioClip` method in `Media2` class based on WSDL changes. (https://github.com/nirsimetri/onvif-python/commit/bc4fddfc4e0a382a69cfc67f8449953f1bfdb3fc)
- Added implementation of exporting and listing recorded segments in `Recording` class based on WSDL changes. (https://github.com/nirsimetri/onvif-python/commit/2ba191a74df65e3390fed9ca78a32624192b1dc6)
- Added implementation of image search methods for NL (natural language/LLM) and image-based queries in `Search` class based on WSDL changes. (https://github.com/nirsimetri/onvif-python/commit/c7f2c9cc1b723a6b40545d5131f9d5d5803a0242)