### PR TITLE
Disable default SSL verification in `ONVIFClient` and `ONVIFOperator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ The `ONVIFClient` class provides various configuration options to customize the 
 |-----------|------|----------|---------|-------------|
 | `timeout` | `int` | ❌ No | `10` | Connection timeout in seconds for SOAP requests |
 | `use_https` | `bool` | ❌ No | `False` | Use HTTPS instead of HTTP for secure communication |
-| `verify_ssl` | `bool` | ❌ No | `True` | Verify SSL certificates when using HTTPS (set to `False` for self-signed certificates) |
+| `verify_ssl` | `bool` | ❌ No | `False` | Verify SSL certificates when using HTTPS (set to `False` for self-signed certificates) |
 
 </details>
 

--- a/README_ID.md
+++ b/README_ID.md
@@ -709,7 +709,7 @@ Kelas `ONVIFClient` menyediakan berbagai opsi konfigurasi untuk menyesuaikan per
 |-----------|------|-------|---------|-----------|
 | `timeout` | `int` | ❌ Tidak | `10` | Timeout koneksi dalam detik untuk permintaan SOAP |
 | `use_https` | `bool` | ❌ Tidak | `False` | Gunakan HTTPS sebagai pengganti HTTP untuk komunikasi aman |
-| `verify_ssl` | `bool` | ❌ Tidak | `True` | Verifikasi sertifikat SSL saat menggunakan HTTPS (set ke `False` untuk sertifikat self-signed) |
+| `verify_ssl` | `bool` | ❌ Tidak | `False` | Verifikasi sertifikat SSL saat menggunakan HTTPS (set ke `False` untuk sertifikat self-signed) |
 
 </details>
 

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -111,7 +111,7 @@ class ONVIFClient:
         timeout: int = 10,
         cache: CacheMode = CacheMode.ALL,
         use_https: bool = False,
-        verify_ssl: bool = True,
+        verify_ssl: bool = False,
         apply_patch: bool = True,
         capture_xml: bool = False,
         wsdl_dir: str | None = None,

--- a/onvif/operator.py
+++ b/onvif/operator.py
@@ -91,7 +91,7 @@ class ONVIFOperator:
         cache: CacheMode = CacheMode.ALL,  # all | db | mem | none
         cache_path: str | None = None,
         use_https: bool = False,
-        verify_ssl: bool = True,
+        verify_ssl: bool = False,
         apply_patch: bool = True,
         plugins: list | None = None,
     ):
@@ -148,9 +148,9 @@ class ONVIFOperator:
 
         ClientType: type[Client | CachingClient]  # pylint: disable=invalid-name
 
-        if cache == CacheMode.ALL or cache == CacheMode.MEM:
+        if cache in (CacheMode.ALL, CacheMode.MEM):
             ClientType = CachingClient
-        elif cache == CacheMode.DB or cache == CacheMode.NONE:
+        elif cache in (CacheMode.DB, CacheMode.NONE):
             ClientType = Client
         else:
             raise ValueError(f"Unknown cache option: {cache}")


### PR DESCRIPTION
In previous versions, `verify_ssl` defaulted to `True` because external schema dependencies requests were still being made over the internet; however, following PR #13 all external schema dependencies files have been localized, so the default value for `verify_ssl` should now be changed to `False`.