### PR TITLE
Enforce pylint standard on examples scripts

### DIFF
--- a/examples/add_media_profile.py
+++ b/examples/add_media_profile.py
@@ -112,7 +112,7 @@ try:
     )
     print(f"Stream URI: {stream_uri.Uri}")
 
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(f"Error: {e}")
     import traceback
 

--- a/examples/add_onvif_user.py
+++ b/examples/add_onvif_user.py
@@ -24,5 +24,5 @@ try:
 
     # print current users to verify addition
     print(device.GetUsers())
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/check_all_capabilities.py
+++ b/examples/check_all_capabilities.py
@@ -19,5 +19,5 @@ try:
     client = ONVIFClient(HOST, PORT, USERNAME, PASSWORD, cache=CacheMode.NONE)
     capabilities = client.devicemgmt().GetCapabilities(Category="All")
     print(capabilities)
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/check_all_services.py
+++ b/examples/check_all_services.py
@@ -19,5 +19,5 @@ try:
     client = ONVIFClient(HOST, PORT, USERNAME, PASSWORD)
     services = client.devicemgmt().GetServices(IncludeCapability=True)
     print(services)
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/check_device.py
+++ b/examples/check_device.py
@@ -23,9 +23,9 @@ try:
     device = client.devicemgmt()
 
     # print device information
-    print(json.dumps(device.GetDeviceInformation().to_dict(), indent=4))
+    print(json.dumps(device.to_dict(device.GetDeviceInformation()), indent=4))
 
     # print device scopes
-    print(json.dumps(device.GetScopes().to_dict(), indent=4))
-except Exception as e:
+    print(json.dumps(device.to_dict(device.GetScopes()), indent=4))
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/check_ptz.py
+++ b/examples/check_ptz.py
@@ -19,7 +19,7 @@ PASSWORD = "admin123"
 try:
     client = ONVIFClient(HOST, PORT, USERNAME, PASSWORD)
     media = client.media()
-    profile = media.GetProfiles()[0]
+    profile = media.GetProfiles()[0]  # use first profile
     ptz = client.ptz()
 
     ptz.ContinuousMove(
@@ -33,5 +33,5 @@ try:
     )
     sleep(2.5)
     ptz.Stop(ProfileToken=profile.token)
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/device_discovery.py
+++ b/examples/device_discovery.py
@@ -17,5 +17,5 @@ try:
     discovery = ONVIFDiscovery(timeout=5)
     devices = discovery.discover()
     print(json.dumps(devices, indent=2))
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/device_scanner.py
+++ b/examples/device_scanner.py
@@ -36,7 +36,7 @@ def is_onvif(ip, port, timeout=3):
             if "xml" in ctype or "soap" in ctype or "onvif" in text:
                 return True
         return False
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         return False
 
 
@@ -69,5 +69,5 @@ if __name__ == "__main__":
         # print(is_onvif("192.168.1.3", 80))
         results = scan_onvif_devices(args.subnet)
         print(json.dumps(results, indent=4))
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         print(e)

--- a/examples/get_imaging.py
+++ b/examples/get_imaging.py
@@ -25,5 +25,5 @@ try:
             VideoSourceToken=profile.VideoSourceConfiguration.SourceToken
         )
     )
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/get_media_profiles.py
+++ b/examples/get_media_profiles.py
@@ -21,5 +21,5 @@ try:
 
     # print available media profiles
     print(device.GetProfiles())
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/get_onvif_version.py
+++ b/examples/get_onvif_version.py
@@ -25,5 +25,5 @@ try:
             service["Namespace"] == "http://www.onvif.org/ver10/device/wsdl"
         ):  # ONVIF Version is from Device service
             print(service["Version"])
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/get_snapshot.py
+++ b/examples/get_snapshot.py
@@ -24,5 +24,5 @@ try:
 
     snapshot_uri = media.GetSnapshotUri(ProfileToken=profile.token)
     print("Snapshot URI:", snapshot_uri.Uri)
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/open_stream_with_ptz.py
+++ b/examples/open_stream_with_ptz.py
@@ -52,8 +52,8 @@ if not cap.isOpened():
     print("❌ Failed to open RTSP stream:", rtsp_url_with_auth)
     sys.exit(1)
 
-print("✅ Streaming started.")
-print("ℹ️ Use keys W/S/A/D to tilt/pan, Q/E to zoom in/out, ESC to quit.")
+print("Streaming started.")
+print("Use keys W/S/A/D to tilt/pan, Q/E to zoom in/out, ESC to quit.")
 
 # PTZ control parameters
 pan_speed = 0.5
@@ -62,6 +62,7 @@ zoom_speed = 0.5
 
 
 def move(ptz, token, pan=0, tilt=0, zoom=0):
+    """PTZ Movements."""
     velocity = {}
     if pan or tilt:
         velocity["PanTilt"] = {"x": pan, "y": tilt}
@@ -71,6 +72,7 @@ def move(ptz, token, pan=0, tilt=0, zoom=0):
 
 
 def stop(ptz, token):
+    """Stop any PTZ Movements."""
     ptz.Stop(ProfileToken=token, PanTilt=True, Zoom=True)
 
 

--- a/examples/pull_live_events.py
+++ b/examples/pull_live_events.py
@@ -118,7 +118,7 @@ while datetime.datetime.now() < end_time:
                     print("\n-> Event without Message")
         else:
             print("\n-> 🔁 No new events.")
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         print("\n-> ❌ Error while pulling events:", e)
 
     # time.sleep(1)  # small delay between requests

--- a/examples/set_device_time.py
+++ b/examples/set_device_time.py
@@ -49,5 +49,5 @@ try:
 
     system_date_time_after = device_service.GetSystemDateAndTime()
     print(f"Updated System Date and Time: {system_date_time_after}\n")
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)

--- a/examples/set_imaging.py
+++ b/examples/set_imaging.py
@@ -1,0 +1,36 @@
+"""
+Path: examples/set_imaging.py
+Author: @kaburagisec
+Created: September 07, 2026
+Tested devices: UNIVIEW Uho-S2E (https://www.uniarch.cn//Products/Wireless_Series/Basic_Series/Basic_Series/Uho-S2E-M4/)
+
+This script connects to an ONVIF-compliant device and sets the Imaging settings
+with defined parameters.
+"""
+
+from onvif import ONVIFClient
+
+HOST = "192.168.1.3"
+PORT = 80
+USERNAME = "admin"
+PASSWORD = "admin123"
+
+try:
+    client = ONVIFClient(HOST, PORT, USERNAME, PASSWORD)
+    media = client.media()
+    profile = media.GetProfiles()[0]  # use first profile
+    video_source_token = profile.VideoSourceConfiguration.SourceToken
+
+    imaging = client.imaging()
+    imaging.SetImagingSettings(
+        VideoSourceToken=video_source_token,
+        ImagingSettings={
+            "Brightness": 50.0,
+            "Contrast": 50.0,
+            "WideDynamicRange": {"Mode": "ON", "Level": 50.0},
+        },
+    )
+
+    print(imaging.GetImagingSettings(VideoSourceToken=video_source_token))
+except Exception as e:  # pylint: disable=broad-exception-caught
+    print(e)

--- a/examples/set_irlamp.py
+++ b/examples/set_irlamp.py
@@ -16,18 +16,19 @@ USERNAME = "admin"
 PASSWORD = "admin123"
 
 try:
-    # Normal vendor implement IR (Infra Red) lamp control via Imaging service
-    # Here we set it to ON, OFF or AUTO (if supported by the camera)
     client = ONVIFClient(HOST, PORT, USERNAME, PASSWORD)
     media = client.media()
-    profile = media.GetProfiles()[0]
+    profile = media.GetProfiles()[0]  # use first profile
     video_source_token = profile.VideoSourceConfiguration.SourceToken
 
     imaging = client.imaging()
+
+    # Normal vendor implement IR (Infra Red) lamp control via Imaging service
+    # Here we set it to ON, OFF or AUTO (if supported by the camera)
     imaging.SetImagingSettings(
         VideoSourceToken=video_source_token, ImagingSettings={"IrCutFilter": "ON"}
     )
 
     print(imaging.GetImagingSettings(VideoSourceToken=video_source_token))
-except Exception as e:
+except Exception as e:  # pylint: disable=broad-exception-caught
     print(e)


### PR DESCRIPTION
- Added an example `set_imaging.py` script for configuring camera imaging settings.
- Applying `pylint` standards to the majority of example scripts (not yet all of them)