### PR TITLE
Add HTTP Digest authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,8 +697,9 @@ The `ONVIFClient` class provides various configuration options to customize the 
 |-----------|------|----------|---------|-------------|
 | `host` | `str` | ✅ Yes | - | IP address or hostname of the ONVIF device (e.g., `"192.168.1.17"`) |
 | `port` | `int` | ✅ Yes | - | Port number for ONVIF service (common ports: `80`, `8000`, `8080`) |
-| `username` | `str` | ✅ Yes | - | Username for device authentication (use digest authentication) |
-| `password` | `str` | ✅ Yes | - | Password for device authentication |
+| `username` | `str` | ❌ No | - | Username for device authentication |
+| `password` | `str` | ❌ No | - | Password for device authentication |
+| `http_digest` | `str` | ❌ No | `False` | `True` = use HTTP Digest / `False` = use WS-Usernametoken |
 
 </details>
 

--- a/README_ID.md
+++ b/README_ID.md
@@ -697,8 +697,9 @@ Kelas `ONVIFClient` menyediakan berbagai opsi konfigurasi untuk menyesuaikan per
 |-----------|------|-------|---------|-----------|
 | `host` | `str` | ✅ Ya | - | Alamat IP atau hostname perangkat ONVIF (mis., `"192.168.1.17"`) |
 | `port` | `int` | ✅ Ya | - | Nomor port untuk layanan ONVIF (port umum: `80`, `8000`, `8080`) |
-| `username` | `str` | ✅ Ya | - | Nama pengguna untuk autentikasi perangkat (menggunakan digest authentication) |
-| `password` | `str` | ✅ Ya | - | Kata sandi untuk autentikasi perangkat |
+| `username` | `str` | ❌ Tidak | - | Nama pengguna untuk autentikasi perangkat |
+| `password` | `str` | ❌ Tidak | - | Kata sandi untuk autentikasi perangkat |
+| `http_digest` | `str` | ❌ Tidak | `False` | `True` = pakai HTTP Digest / `False` = pakai WS-Usernametoken |
 
 </details>
 

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -111,9 +111,9 @@ class ONVIFClient:
         self,
         host: str,
         port: int,
-        http_digest: bool = False,  # will use WS-Usernametoken by default (recommended! trust me)
         username: str | None = None,
         password: str | None = None,
+        http_digest: bool = False,  # will use WS-Usernametoken by default (recommended! trust me)
         timeout: int = 10,
         cache: CacheMode = CacheMode.ALL,
         use_https: bool = False,
@@ -152,9 +152,9 @@ class ONVIFClient:
         self.common_args = {
             "host": host,
             "port": port,
-            "http_digest": http_digest,
             "username": username,
             "password": password,
+            "http_digest": http_digest,
             "timeout": timeout,
             "cache": cache,
             "use_https": use_https,

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -111,8 +111,9 @@ class ONVIFClient:
         self,
         host: str,
         port: int,
-        username: str,
-        password: str,
+        http_digest: bool = False,  # will use WS-Usernametoken by default (recommended! trust me)
+        username: str | None = None,
+        password: str | None = None,
         timeout: int = 10,
         cache: CacheMode = CacheMode.ALL,
         use_https: bool = False,
@@ -142,7 +143,7 @@ class ONVIFClient:
         )
 
         # Store custom WSDL directory if provided
-        self.wsdl_dir = wsdl_dir
+        self.wsdl_dir: str | None = wsdl_dir
         if wsdl_dir:
             logger.debug("Using custom WSDL directory: %s", wsdl_dir)
             ONVIFWSDL.set_custom_wsdl_dir(wsdl_dir)
@@ -151,6 +152,7 @@ class ONVIFClient:
         self.common_args = {
             "host": host,
             "port": port,
+            "http_digest": http_digest,
             "username": username,
             "password": password,
             "timeout": timeout,

--- a/onvif/operator.py
+++ b/onvif/operator.py
@@ -9,6 +9,8 @@ from enum import Enum
 
 import requests
 import urllib3
+from requests.auth import HTTPDigestAuth
+from requests import Session
 from zeep import CachingClient, Client, Settings, Transport
 from zeep.cache import SqliteCache
 from zeep.exceptions import Fault
@@ -83,8 +85,9 @@ class ONVIFOperator:
         wsdl_path: str,
         host: str,
         port: int,
-        username: str,
-        password: str,
+        http_digest: bool = False,  # True = use HTTP Digest / False = use WS-Usernametoken
+        username: str | None = None,
+        password: str | None = None,
         timeout: int = 10,
         binding: str | None = None,
         service_path: str | None = None,
@@ -100,13 +103,14 @@ class ONVIFOperator:
             "Creating ONVIFOperator for %s:%d with WSDL: %s", host, port, wsdl_path
         )
 
-        self.wsdl_path = wsdl_path
-        self.host = host
-        self.port = port
-        self.username = username
-        self.password = password
-        self.timeout = timeout
-        self.apply_patch = apply_patch
+        self.wsdl_path: str = wsdl_path
+        self.http_digest: bool = http_digest
+        self.host: str = host
+        self.port: int = port
+        self.username: str | None = username
+        self.password: str | None = password
+        self.timeout: int = timeout
+        self.apply_patch: bool = apply_patch
 
         if xaddr:
             self.address = xaddr
@@ -118,13 +122,7 @@ class ONVIFOperator:
         logger.debug("Service endpoint: %s", self.address)
 
         # Session reuse with retry strategy
-        session = requests.Session()
-        session.verify = verify_ssl
-
-        # Format SSL warnings to be more concise when verify_ssl is False
-        if not verify_ssl:
-            logger.debug("SSL verification disabled")
-            warnings.simplefilter("once", urllib3.exceptions.InsecureRequestWarning)
+        session: Session = self._create_session(verify_ssl=verify_ssl)
 
         transport_kwargs = {"session": session, "operation_timeout": timeout}
 
@@ -141,11 +139,7 @@ class ONVIFOperator:
 
         # zeep settings
         settings = Settings(strict=False, xml_huge_tree=True)
-        wsse = (
-            UsernameToken(username, password, use_digest=True)
-            if username and password
-            else None
-        )
+        wsse: UsernameToken | None = self._create_wsse()
 
         ClientType: type[Client | CachingClient]  # pylint: disable=invalid-name
 
@@ -174,6 +168,61 @@ class ONVIFOperator:
             "Binding", ""
         )  # Store cleaned service name for logging context
         logger.info("ONVIFOperator initialized %s at %s", binding, self.address)
+
+    def _create_session(
+        self,
+        verify_ssl: bool,
+    ) -> Session:
+        """Create and configure the HTTP session.
+
+        Args:
+            verify_ssl: Whether SSL certificates should be verified.
+
+        Returns:
+            Configured requests session.
+        """
+        session = requests.Session()
+        session.verify = verify_ssl
+
+        if not verify_ssl:
+            # Format SSL warnings to be more concise when verify_ssl is False
+            logger.debug("SSL verification disabled")
+            warnings.simplefilter(
+                "once",
+                urllib3.exceptions.InsecureRequestWarning,
+            )
+
+        if self.http_digest and self.username and self.password:
+            logger.debug("Configuring HTTP Digest authentication")
+
+            session.auth = HTTPDigestAuth(
+                self.username,
+                self.password,
+            )
+
+        return session
+
+    def _create_wsse(
+        self,
+    ) -> UsernameToken | None:
+        """Create WS-Security authentication configuration.
+
+        Returns:
+            Zeep WS-Security UsernameToken or None.
+        """
+        if self.http_digest:
+            return None
+
+        if not self.username or not self.password:
+            return None
+
+        logger.debug("Configuring WS-Security UsernameToken authentication")
+
+        return UsernameToken(
+            self.username,
+            self.password,
+            use_digest=True,
+        )
 
     def call(self, method: str, *args, **kwargs):
         """Call an ONVIF service operation.

--- a/onvif/operator.py
+++ b/onvif/operator.py
@@ -72,6 +72,7 @@ class ONVIFOperator:
         port (int): Device port number
         username (str): ONVIF username
         password (str): ONVIF password
+        http_digest (bool): Whether to use HTTP Digest or WS-Usernametoken for auth
         timeout (int): Request timeout in seconds
         apply_patch (bool): Whether to apply xsd:any flattening patch
         address (str): Service endpoint URL (XAddr)
@@ -85,9 +86,9 @@ class ONVIFOperator:
         wsdl_path: str,
         host: str,
         port: int,
-        http_digest: bool = False,  # True = use HTTP Digest / False = use WS-Usernametoken
         username: str | None = None,
         password: str | None = None,
+        http_digest: bool = False,  # True = use HTTP Digest / False = use WS-Usernametoken
         timeout: int = 10,
         binding: str | None = None,
         service_path: str | None = None,


### PR DESCRIPTION
This PR allows clients to use HTTP Digest authentication via param `http_digest` or no authentication at all (i.e., empty username and password).