### PR TITLE
Fix tab completion compatibility for Windows

### DIFF
--- a/onvif/cli/interactive.py
+++ b/onvif/cli/interactive.py
@@ -83,12 +83,14 @@ class InteractiveShell(cmd.Cmd):
         )
 
         # Enable tab completion
+        # for Windows will use pyreadline3 to install readline module
+        # pylint: disable=import-outside-toplevel
         try:
             import readline
 
             # Set completer to this instance
-            readline.set_completer(self.complete)
-            readline.set_completer_delims(" \t\n`!@#$%^&*()=+[{]}\\|;:'\",<>?")
+            readline.set_completer(self.complete)  # type: ignore[attr-defined]
+            readline.set_completer_delims(" \t\n`!@#$%^&*()=+[{]}\\|;:'\",<>?")  # type: ignore[attr-defined]
 
             # Enable tab completion, making it compatible with both GNU readline and libedit
             if (
@@ -96,9 +98,9 @@ class InteractiveShell(cmd.Cmd):
                 and readline.__doc__
                 and "libedit" in readline.__doc__
             ):
-                readline.parse_and_bind("bind ^I rl_complete")
+                readline.parse_and_bind("bind ^I rl_complete")  # type: ignore[attr-defined]
             else:
-                readline.parse_and_bind("tab: complete")
+                readline.parse_and_bind("tab: complete")  # type: ignore[attr-defined]
         except ImportError:
             pass  # readline not available on some systems
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ license = "MIT"
 dependencies = [
     "zeep>=4.3.0",
     "requests>=2.32.0",
+    'pyreadline3>=3.5.4; sys_platform == "win32"',
 ]
 
 [build-system]


### PR DESCRIPTION
This PR adds the https://github.com/pyreadline3/pyreadline3 dependency to make the `readline` module available on Windows, fixing Tab Completion compatibility in the interactive shell.