### PR TITLE
Add support for HTTP Digest authentication argument

### DIFF
--- a/onvif/cli/helpers/messages.py
+++ b/onvif/cli/helpers/messages.py
@@ -69,7 +69,8 @@ def print_interactive_intro(args, device_info_text) -> str:
         f"{banner}\n"
         f"{repo_info}\n"
         f"{terminal_header}\n"
-        f"  Connected to  : {colorize(f'{args.host}:{args.port}', 'yellow')}"
+        f"  Connected to  : {colorize(f'{args.host}:{args.port}', 'yellow')}\n"
+        f"  Auth Method   : {colorize(f'{'HTTP Digest' if args.digest else 'WS-Username Token'}', 'yellow')}"
         f"{options_display}{device_info_text}\n\n"
         f"{colorize('[Quick Start]', 'green')}\n"
         f"  - Type {colorize('dev', 'yellow')} + {colorize('TAB', 'yellow')} to see `devicemgmt` suggestion\n"
@@ -193,7 +194,7 @@ Examples:
   # Discover ONVIF devices on network
   {colorize('onvif', 'yellow')} --discover --username admin --password admin123 --interactive
   {colorize('onvif', 'yellow')} media GetProfiles --discover --username admin
-  {colorize('onvif', 'yellow')} -d -i
+  {colorize('onvif', 'yellow')} -d --interface 192.168.1.77 -i
 
   # Discover with filtering
   {colorize('onvif', 'yellow')} --discover --filter ptz --interactive

--- a/onvif/cli/interactive.py
+++ b/onvif/cli/interactive.py
@@ -1221,6 +1221,7 @@ class InteractiveShell(cmd.Cmd):
         print(
             f"\n{colorize('[ONVIF Terminal Client]', 'yellow')}"
             f"\n  Connected to  : {colorize(f'{self.args.host}:{self.args.port}', 'yellow')}"
+            f"\n  Auth Method   : {colorize(f'{'HTTP Digest' if self.args.digest else 'WS-Usernametoken'}', 'yellow')}"
             f"{options_display}{self.device_info_text}"
         )
         print()  # Extra newline for spacing

--- a/onvif/cli/main.py
+++ b/onvif/cli/main.py
@@ -24,7 +24,6 @@ from onvif.operator import CacheMode
 from onvif.utils import ONVIFOperationException
 
 
-# pylint: disable=line-too-long
 def create_parser() -> ArgumentParser:
     """Create argument parser for ONVIF CLI."""
     parser = ArgumentParser(
@@ -96,6 +95,11 @@ def create_parser() -> ArgumentParser:
         type=int,
         default=10,
         help="ONVIF connection timeout in seconds (default: 10)",
+    )
+    parser.add_argument(
+        "--digest",
+        action="store_true",
+        help="Use HTTP Digest instead of WS-Usernametoken",
     )
     parser.add_argument(
         "--https", action="store_true", help="Use HTTPS instead of HTTP"
@@ -278,6 +282,7 @@ def main() -> None:
             port=args.port,
             username=args.username,
             password=args.password,
+            http_digest=args.digest,
             timeout=args.timeout,
             cache=CacheMode(args.cache),
             use_https=args.https,

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -127,7 +127,7 @@ class ONVIFClient:
         port: int,
         username: str | None = None,
         password: str | None = None,
-        http_digest: bool = False,  # will use WS-Usernametoken by default (recommended! trust me)
+        http_digest: bool = False,  # will use WS-Usernametoken by default
         timeout: int = 10,
         cache: CacheMode = CacheMode.ALL,
         use_https: bool = False,


### PR DESCRIPTION
The ONVIF CLI now allows specifying the HTTP Digest authentication method when connecting to a device by adding the `--digest` argument; if omitted, the WS-UsernameToken (default) method is used.