### PR TITLE
Replace `ONVIFErrorHandler` with module-level functions

### DIFF
--- a/examples/error_handling.py
+++ b/examples/error_handling.py
@@ -8,10 +8,20 @@ This example demonstrates various ways to handle ONVIF operation errors,
 especially dealing with ActionNotSupported errors from devices that don't
 support certain features.
 
-Applied for (>= v0.0.7 patch)
+Applied for (>=v0.0.7 patch)
+Modified to module from (>=v0.3.2 patch)
 """
 
-from onvif import CacheMode, ONVIFClient, ONVIFErrorHandler, ONVIFOperationException
+import traceback
+
+from onvif import (
+    CacheMode,
+    ONVIFClient,
+    ONVIFOperationException,
+    ignore_unsupported,
+    is_action_not_supported,
+    safe_call,
+)
 
 HOST = "192.168.1.14"
 PORT = 2020
@@ -34,16 +44,14 @@ def example_1_safe_call():
     device = client.devicemgmt()
 
     # Returns None if operation is not supported
-    ip_filter = ONVIFErrorHandler.safe_call(lambda: device.GetIPAddressFilter())
+    ip_filter = safe_call(device.GetIPAddressFilter)
     if ip_filter:
         print(f"✓ IP Address Filter: {ip_filter}")
     else:
         print("⚠ GetIPAddressFilter not supported or returned None")
 
     # Returns empty list if operation is not supported
-    dns_info = ONVIFErrorHandler.safe_call(
-        lambda: device.GetDNS(), default={"FromDHCP": False, "DNSManual": []}
-    )
+    dns_info = safe_call(device.GetDNS, default={"FromDHCP": False, "DNSManual": []})
     print(f"✓ DNS Info: {dns_info}")
 
     print()
@@ -63,11 +71,11 @@ def example_2_decorator():
     client = ONVIFClient(HOST, PORT, USERNAME, PASSWORD, cache=CacheMode.NONE)
     device = client.devicemgmt()
 
-    @ONVIFErrorHandler.ignore_unsupported
+    @ignore_unsupported
     def get_zero_configuration():
         return device.GetZeroConfiguration()
 
-    @ONVIFErrorHandler.ignore_unsupported
+    @ignore_unsupported
     def get_ntp():
         return device.GetNTP()
 
@@ -128,7 +136,7 @@ def example_3_manual_handling():
             print(f"  System Backup: {system_uris.SystemBackupUri}")
 
     except ONVIFOperationException as e:
-        if ONVIFErrorHandler.is_action_not_supported(e):
+        if is_action_not_supported(e):
             print("⚠ GetSystemUris not supported by this device")
             print("  Using alternative method to get device info...")
 
@@ -164,15 +172,15 @@ def example_4_batch_operations():
 
     # Define operations to try
     operations = {
-        "Device Info": lambda: device.GetDeviceInformation(),
-        "System Date/Time": lambda: device.GetSystemDateAndTime(),
-        "Network Interfaces": lambda: device.GetNetworkInterfaces(),
-        "Hostname": lambda: device.GetHostname(),
-        "DNS": lambda: device.GetDNS(),
-        "NTP": lambda: device.GetNTP(),
-        "Network Protocols": lambda: device.GetNetworkProtocols(),
-        "IP Address Filter": lambda: device.GetIPAddressFilter(),
-        "Zero Configuration": lambda: device.GetZeroConfiguration(),
+        "Device Info": device.GetDeviceInformation,
+        "System Date/Time": device.GetSystemDateAndTime,
+        "Network Interfaces": device.GetNetworkInterfaces,
+        "Hostname": device.GetHostname,
+        "DNS": device.GetDNS,
+        "NTP": device.GetNTP,
+        "Network Protocols": device.GetNetworkProtocols,
+        "IP Address Filter": device.GetIPAddressFilter,
+        "Zero Configuration": device.GetZeroConfiguration,
         "Services": lambda: device.GetServices(IncludeCapability=False),
     }
 
@@ -181,7 +189,7 @@ def example_4_batch_operations():
     unsupported_count = 0
 
     for name, operation in operations.items():
-        result = ONVIFErrorHandler.safe_call(operation, default=None, log_error=False)
+        result = safe_call(operation, default=None, log_error=False)
         results[name] = result
 
         if result is not None:
@@ -200,7 +208,7 @@ def example_5_critical_operations():
     Example 5: Critical operations that should not be ignored
 
     Some operations are critical and should fail loudly if not supported.
-    Use ignore_unsupported=False for these.
+    Use handle_unsupported=False for these.
     """
     print("=" * 60)
     print("Example 5: Critical operations (don't ignore errors)")
@@ -211,9 +219,9 @@ def example_5_critical_operations():
 
     # Critical operation - must succeed
     try:
-        device_info = ONVIFErrorHandler.safe_call(
-            lambda: device.GetDeviceInformation(),
-            ignore_unsupported=False,  # Raise exception if not supported
+        device_info = safe_call(
+            device.GetDeviceInformation,
+            handle_unsupported=False,  # Raise exception if not supported
         )
         print("✓ Device Info (critical):")
         print(f"  Manufacturer: {getattr(device_info, 'Manufacturer', 'N/A')}")
@@ -242,7 +250,6 @@ def main():
 
     except Exception as e:
         print(f"\n✗ Fatal error: {e}")
-        import traceback
 
         traceback.print_exc()
 

--- a/onvif/__init__.py
+++ b/onvif/__init__.py
@@ -6,10 +6,12 @@ from onvif.operator import CacheMode
 from onvif.utils import (
     ONVIFWSDL,
     ONVIFDiscovery,
-    ONVIFErrorHandler,
     ONVIFOperationException,
     ONVIFParser,
     ZeepPatcher,
+    ignore_unsupported,
+    is_action_not_supported,
+    safe_call,
 )
 
 __all__ = [
@@ -17,9 +19,11 @@ __all__ = [
     "CacheMode",
     "ONVIFWSDL",
     "ONVIFOperationException",
-    "ONVIFErrorHandler",
     "ZeepPatcher",
     "ONVIFCLI",
     "ONVIFDiscovery",
     "ONVIFParser",
+    "ignore_unsupported",
+    "is_action_not_supported",
+    "safe_call",
 ]

--- a/onvif/utils/__init__.py
+++ b/onvif/utils/__init__.py
@@ -1,7 +1,11 @@
 """Utility functions and classes for ONVIF operations."""
 
 from onvif.utils.discovery import ONVIFDiscovery
-from onvif.utils.error_handlers import ONVIFErrorHandler
+from onvif.utils.error_handlers import (
+    ignore_unsupported,
+    is_action_not_supported,
+    safe_call,
+)
 from onvif.utils.exceptions import ONVIFOperationException
 from onvif.utils.plugins import ONVIFParser, XMLCapturePlugin
 from onvif.utils.service import ONVIFService
@@ -13,8 +17,10 @@ __all__ = [
     "ONVIFOperationException",
     "ZeepPatcher",
     "XMLCapturePlugin",
-    "ONVIFErrorHandler",
     "ONVIFDiscovery",
     "ONVIFService",
     "ONVIFParser",
+    "ignore_unsupported",
+    "is_action_not_supported",
+    "safe_call",
 ]

--- a/onvif/utils/error_handlers.py
+++ b/onvif/utils/error_handlers.py
@@ -1,4 +1,37 @@
-"""ONVIFErrorHandler: Error handling utilities for ONVIF operations."""
+"""
+Error handling utilities for ONVIF operations.
+
+This module provides utilities to gracefully handle ONVIF SOAP errors,
+particularly the common `ActionNotSupported` fault that occurs when devices
+don't implement certain optional ONVIF operations.
+
+ONVIF devices may not support all operations defined in the specification.
+When an unsupported operation is called, the device returns a SOAP fault with
+the `ActionNotSupported` subcode. These utilities help detect and handle such
+cases.
+
+!!! abstract "Features"
+    - Detect `ActionNotSupported` SOAP faults
+    - Provide safe operation calls with default fallbacks
+    - Ignore unsupported operations using a decorator
+    - Support graceful degradation in multi-device environments
+
+!!! tip "Common Use Cases"
+    1. **Feature Detection**: Check if a device supports an operation
+    2. **Graceful Degradation**: Continue execution when an operation fails
+    3. **Multi-Device Support**: Handle devices with varying capabilities
+    4. **Safe Exploration**: Test operations without crashing
+
+??? note "Notes"
+    - Works with both `ONVIFOperationException` and raw `zeep.Fault`
+    - Preserves stack traces for non-`ActionNotSupported` errors
+    - Minimal performance overhead for supported operations
+    - Thread-safe because no shared state is maintained
+
+??? note "See Also"
+    - [`ONVIFOperationException`](onvif_exception.md): Custom exception wrapper
+    - `zeep.exceptions.Fault`: Base SOAP fault exception
+"""
 
 import logging
 from typing import Any
@@ -11,120 +44,187 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-class ONVIFErrorHandler:
-    """Error handling utilities for ONVIF operations.
+def is_action_not_supported(exception) -> bool:
+    """
+    Check whether an exception is caused by an `ActionNotSupported` SOAP fault.
 
-    This class provides static methods to gracefully handle ONVIF SOAP errors,
-    particularly the common "ActionNotSupported" fault that occurs when devices
-    don't implement certain optional ONVIF operations.
+    Args:
+        exception: The exception to inspect. Can be an
+            `ONVIFOperationException` or a raw `zeep.exceptions.Fault`.
 
-    ONVIF devices may not support all operations defined in the specification.
-    When an unsupported operation is called, the device returns a SOAP fault with
-    the "ActionNotSupported" subcode. This class helps detect and handle such cases.
+    Returns:
+        `True` if the exception contains an `ActionNotSupported` SOAP fault, `False` otherwise.
 
-    Key Features:
-        - Detect ActionNotSupported SOAP faults
-        - Provide safe operation calls with default fallbacks
-        - Decorator pattern for ignoring unsupported operations
-        - Wrapper for graceful degradation in multi-device environments
+    Example:
+        ```python
+        from onvif import ONVIFClient, is_action_not_supported
 
-    Common Use Cases:
-        1. **Feature Detection**: Check if device supports an operation
-        2. **Graceful Degradation**: Continue execution when operation fails
-        3. **Multi-Device Support**: Handle devices with varying capabilities
-        4. **Safe Exploration**: Test operations without crashing
+        try:
+            client = ONVIFClient("192.168.1.17", 80, "admin", "password")
+            device = client.devicemgmt()
+            system_uris = device.GetSystemUris()
+        except ONVIFOperationException as e:
+            if is_action_not_supported(e):
+                # Fallback: Get basic device information
+                device_info = device.GetDeviceInformation()
+        ```
+    """
+    try:
+        # Handle ONVIFOperationException
+        if isinstance(exception, ONVIFOperationException):
+            original = exception.original_exception
+        else:
+            original = exception
 
-    Notes:
-        - All methods are static - no need to instantiate the class
-        - Works with both ONVIFOperationException and raw zeep.Fault
-        - Preserves stack traces for non-ActionNotSupported errors
-        - Minimal performance overhead for supported operations
-        - Thread-safe (no shared state)
+        if not isinstance(original, Fault):
+            return False
 
-    See Also:
-        - ONVIFOperationException: Custom exception wrapper
-        - zeep.exceptions.Fault: Base SOAP fault exception
+        subcodes = getattr(original, "subcodes", None)
+        if not subcodes:
+            return False
+
+        for subcode in subcodes:
+            localname = getattr(subcode, "localname", None)
+
+            if localname == "ActionNotSupported":
+                logger.debug("Detected ActionNotSupported fault")
+                return True
+
+            if "ActionNotSupported" in str(subcode):
+                logger.debug("Detected ActionNotSupported fault in subcode")
+                return True
+
+    except OSError as error:
+        logger.debug("Error checking ActionNotSupported: %s", error)
+
+    return False
+
+
+def safe_call(
+    func, default=None, handle_unsupported=True, log_error=True
+) -> Any | None:
+    """
+    Safely call an ONVIF operation with graceful error handling.
+
+    Args:
+        func: The callable that performs the ONVIF operation.
+        default: The value to return when the operation is unsupported and
+            `handle_unsupported` is enabled. Defaults to `None`.
+        handle_unsupported: Whether to catch `ActionNotSupported` faults and
+            return `default` instead of raising the exception. Defaults to
+            `True`.
+        log_error: Whether to log errors encountered during the operation.
+            Defaults to `True`.
+
+    Returns:
+        The result returned by `func`, or `default` when the operation is
+            unsupported and `handle_unsupported` is enabled.
+
+    Raises:
+        ONVIFOperationException: If the operation fails for a reason other
+            than `ActionNotSupported`, or if `handle_unsupported` is disabled.
+        Exception: If `func` raises an unexpected exception.
+
+    Example:
+        ```python
+        from onvif import ONVIFClient, safe_call
+
+        client = ONVIFClient("192.168.1.17", 80, "admin", "password")
+        device = client.devicemgmt()
+
+        # Returns None if operation is not supported
+        ip_filter = safe_call(device.GetIPAddressFilter)
+
+        if ip_filter:
+            print(f"IP Address Filter: {ip_filter}")
+        else:
+            print("GetIPAddressFilter not supported or returned None")
+
+        services = safe_call(
+            lambda: device.GetServices(IncludeCapability=False),
+            handle_unsupported=False  # Raise exception if not supported
+        )
+
+        print(f"Found {len(services)} services")
+        ```
+    """
+    try:
+        result = func()
+        logger.debug("Safe call succeeded")
+        return result
+    except ONVIFOperationException as e:
+        # Check if it's ActionNotSupported error
+        if handle_unsupported and is_action_not_supported(e):
+            if log_error:
+                logger.warning("Operation not supported: %s", e.operation)
+            return default
+        # Re-raise other errors
+        if log_error:
+            logger.error("ONVIF operation failed in safe_call: %s", e.operation)
+        raise
+    except Exception as e:  # pylint: disable=broad-except
+        # Wrap unexpected exceptions
+        if log_error:
+            logger.error("Unexpected error in safe_call: %s", e)
+        raise
+
+
+def ignore_unsupported(func) -> Any | None:
+    """Decorator to ignore `ActionNotSupported` SOAP faults.
+
+    Args:
+        func: The function to decorate. The function may accept positional
+            and keyword arguments.
+
+    Returns:
+        A wrapped function that returns `None` when an `ActionNotSupported` fault occurs.
+
+    Raises:
+        ONVIFOperationException: If the decorated function fails for a reason
+            other than `ActionNotSupported`.
+        Exception: If the decorated function raises an unexpected exception.
+
+    Example:
+        ```python
+        from onvif import ONVIFClient, ignore_unsupported
+
+        client = ONVIFClient("192.168.1.17", 80, "admin", "password")
+        device = client.devicemgmt()
+
+        @ignore_unsupported
+        def get_zero_configuration():
+            return device.GetZeroConfiguration()
+
+        @ignore_unsupported
+        def get_ntp():
+            return device.GetNTP()
+
+        zero_conf = get_zero_configuration()
+        if zero_conf:
+            print(f"Zero Configuration: {zero_conf}")
+        else:
+            print("GetZeroConfiguration not supported")
+
+        ntp = get_ntp()
+        if ntp:
+            print(f"NTP: {ntp}")
+        else:
+            print("GetNTP not supported")
+        ```
     """
 
-    @staticmethod
-    def is_action_not_supported(exception) -> bool:
-        """Check whether an exception is caused by an ActionNotSupported SOAP fault."""
+    def wrapper(*args, **kwargs):
         try:
-            # Handle ONVIFOperationException
-            if isinstance(exception, ONVIFOperationException):
-                original = exception.original_exception
-            else:
-                original = exception
-
-            if not isinstance(original, Fault):
-                return False
-
-            subcodes = getattr(original, "subcodes", None)
-            if not subcodes:
-                return False
-
-            for subcode in subcodes:
-                localname = getattr(subcode, "localname", None)
-
-                if localname == "ActionNotSupported":
-                    logger.debug("Detected ActionNotSupported fault")
-                    return True
-
-                if "ActionNotSupported" in str(subcode):
-                    logger.debug("Detected ActionNotSupported fault in subcode")
-                    return True
-
-        except OSError as error:
-            logger.debug("Error checking ActionNotSupported: %s", error)
-
-        return False
-
-    @staticmethod
-    def safe_call(
-        func, default=None, ignore_unsupported=True, log_error=True
-    ) -> Any | None:
-        """Safely call an ONVIF operation with graceful error handling."""
-        try:
-            result = func()
-            logger.debug("Safe call succeeded")
+            result = func(*args, **kwargs)
+            logger.debug("Decorated function %s succeeded", func.__name__)
             return result
         except ONVIFOperationException as e:
-            # Check if it's ActionNotSupported error
-            if ignore_unsupported and ONVIFErrorHandler.is_action_not_supported(e):
-                if log_error:
-                    logger.warning("Operation not supported: %s", e.operation)
-                return default
-            # Re-raise other errors
-            if log_error:
-                logger.error("ONVIF operation failed in safe_call: %s", e.operation)
-            raise
-        except Exception as e:  # pylint: disable=broad-except
-            # Wrap unexpected exceptions
-            if log_error:
-                logger.error("Unexpected error in safe_call: %s", e)
-            raise
-
-    @staticmethod
-    def ignore_unsupported(func) -> Any | None:
-        """Decorator to ignore ActionNotSupported SOAP faults.
-
-        Returns None for unsupported operations, raises other exceptions.
-        """
-
-        def wrapper(*args, **kwargs):
-            try:
-                result = func(*args, **kwargs)
-                logger.debug("Decorated function %s succeeded", func.__name__)
-                return result
-            except ONVIFOperationException as e:
-                if ONVIFErrorHandler.is_action_not_supported(e):
-                    logger.warning(
-                        "Operation not supported in %s: %s", func.__name__, e.operation
-                    )
-                    return None
-                logger.error(
-                    "ONVIF operation failed in %s: %s", func.__name__, e.operation
+            if is_action_not_supported(e):
+                logger.warning(
+                    "Operation not supported in %s: %s", func.__name__, e.operation
                 )
-                raise
+                return None
+            logger.error("ONVIF operation failed in %s: %s", func.__name__, e.operation)
+            raise
 
-        return wrapper
+    return wrapper


### PR DESCRIPTION
Refactor `ONVIFErrorHandler` into module-level functions to simplify the error handling API while preserving existing behavior.